### PR TITLE
Fix PatchExitCommand in dynamic mode

### DIFF
--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -25,18 +25,18 @@ namespace Kamek.Commands
 
         public override string PackForRiivolution()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
-            return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value, GenerateInstruction());
+            return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value.Value, GenerateInstruction());
         }
 
         public override IEnumerable<ulong> PackGeckoCodes()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
-            ulong code = ((ulong)(Address.Value & 0x1FFFFFF) << 32) | GenerateInstruction();
+            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | GenerateInstruction();
             code |= 0x4000000UL << 32;
 
             return new ulong[1] { code };
@@ -44,9 +44,9 @@ namespace Kamek.Commands
 
         public override bool Apply(KamekFile file)
         {
-            if (Address.IsAbsolute && Target.IsAbsolute && file.Contains(Address))
+            if (Address.Value.IsAbsolute && Target.IsAbsolute && file.Contains(Address.Value))
             {
-                file.WriteUInt32(Address, GenerateInstruction());
+                file.WriteUInt32(Address.Value, GenerateInstruction());
                 return true;
             }
 
@@ -55,16 +55,16 @@ namespace Kamek.Commands
 
         public override void ApplyToDol(Dol dol)
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
-            dol.WriteUInt32(Address.Value, GenerateInstruction());
+            dol.WriteUInt32(Address.Value.Value, GenerateInstruction());
         }
 
 
         private uint GenerateInstruction()
         {
-            long delta = Target - Address;
+            long delta = Target - Address.Value;
             uint insn = (Id == Ids.BranchLink) ? 0x48000001U : 0x48000000U;
             insn |= ((uint)delta & 0x3FFFFFC);
             return insn;

--- a/Kamek/Commands/Command.cs
+++ b/Kamek/Commands/Command.cs
@@ -35,9 +35,18 @@ namespace Kamek.Commands
         }
 
         public readonly Ids Id;
-        public readonly Word Address;
 
-        protected Command(Ids id, Word address)
+        private Word? _Address;
+        public Word? Address
+        {
+            get => _Address;
+            protected set
+            {
+                _Address = value;
+            }
+        }
+
+        protected Command(Ids id, Word? address)
         {
             Id = id;
             Address = address;
@@ -48,5 +57,13 @@ namespace Kamek.Commands
         public abstract IEnumerable<ulong> PackGeckoCodes();
         public abstract bool Apply(KamekFile file);
         public abstract void ApplyToDol(Dol dol);
+
+        public virtual void CalculateAddress(KamekFile file) {}
+
+        public void AssertAddressNonNull()
+        {
+            if (!Address.HasValue)
+                throw new NullReferenceException(string.Format("{0} command must have an address in this context", Id));
+        }
     }
 }

--- a/Kamek/Commands/RelocCommand.cs
+++ b/Kamek/Commands/RelocCommand.cs
@@ -35,35 +35,35 @@ namespace Kamek.Commands
 
         public override void ApplyToDol(Dol dol)
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
             switch (Id)
             {
                 case Ids.Rel24:
-                    long delta = Target - Address;
-                    uint insn = dol.ReadUInt32(Address.Value) & 0xFC000003;
+                    long delta = Target - Address.Value;
+                    uint insn = dol.ReadUInt32(Address.Value.Value) & 0xFC000003;
                     insn |= ((uint)delta & 0x3FFFFFC);
-                    dol.WriteUInt32(Address.Value, insn);
+                    dol.WriteUInt32(Address.Value.Value, insn);
                     break;
 
                 case Ids.Addr32:
-                    dol.WriteUInt32(Address.Value, Target.Value);
+                    dol.WriteUInt32(Address.Value.Value, Target.Value);
                     break;
 
                 case Ids.Addr16Lo:
-                    dol.WriteUInt16(Address.Value, (ushort)(Target.Value & 0xFFFF));
+                    dol.WriteUInt16(Address.Value.Value, (ushort)(Target.Value & 0xFFFF));
                     break;
 
                 case Ids.Addr16Hi:
-                    dol.WriteUInt16(Address.Value, (ushort)(Target.Value >> 16));
+                    dol.WriteUInt16(Address.Value.Value, (ushort)(Target.Value >> 16));
                     break;
 
                 case Ids.Addr16Ha:
                     ushort v = (ushort)(Target.Value >> 16);
                     if ((Target.Value & 0x8000) == 0x8000)
                         v++;
-                    dol.WriteUInt16(Address.Value, v);
+                    dol.WriteUInt16(Address.Value.Value, v);
                     break;
 
                 default:
@@ -76,12 +76,12 @@ namespace Kamek.Commands
             switch (Id)
             {
                 case Ids.Rel24:
-                    if ((Address.IsAbsolute && Target.IsAbsolute) || (Address.IsRelative && Target.IsRelative))
+                    if ((Address.Value.IsAbsolute && Target.IsAbsolute) || (Address.Value.IsRelative && Target.IsRelative))
                     {
-                        long delta = Target - Address;
-                        uint insn = file.ReadUInt32(Address) & 0xFC000003;
+                        long delta = Target - Address.Value;
+                        uint insn = file.ReadUInt32(Address.Value) & 0xFC000003;
                         insn |= ((uint)delta & 0x3FFFFFC);
-                        file.WriteUInt32(Address, insn);
+                        file.WriteUInt32(Address.Value, insn);
 
                         return true;
                     }
@@ -90,7 +90,7 @@ namespace Kamek.Commands
                 case Ids.Addr32:
                     if (Target.IsAbsolute)
                     {
-                        file.WriteUInt32(Address, Target.Value);
+                        file.WriteUInt32(Address.Value, Target.Value);
                         return true;
                     }
                     break;
@@ -98,7 +98,7 @@ namespace Kamek.Commands
                 case Ids.Addr16Lo:
                     if (Target.IsAbsolute)
                     {
-                        file.WriteUInt16(Address, (ushort)(Target.Value & 0xFFFF));
+                        file.WriteUInt16(Address.Value, (ushort)(Target.Value & 0xFFFF));
                         return true;
                     }
                     break;
@@ -106,7 +106,7 @@ namespace Kamek.Commands
                 case Ids.Addr16Hi:
                     if (Target.IsAbsolute)
                     {
-                        file.WriteUInt16(Address, (ushort)(Target.Value >> 16));
+                        file.WriteUInt16(Address.Value, (ushort)(Target.Value >> 16));
                         return true;
                     }
                     break;
@@ -117,7 +117,7 @@ namespace Kamek.Commands
                         ushort v = (ushort)(Target.Value >> 16);
                         if ((Target.Value & 0x8000) == 0x8000)
                             v++;
-                        file.WriteUInt16(Address, v);
+                        file.WriteUInt16(Address.Value, v);
                         return true;
                     }
                     break;

--- a/Kamek/Commands/WriteCommand.cs
+++ b/Kamek/Commands/WriteCommand.cs
@@ -75,7 +75,7 @@ namespace Kamek.Commands
 
         public override string PackForRiivolution()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             if (ValueType == Type.Pointer)
                 Value.AssertAbsolute();
             else
@@ -87,20 +87,20 @@ namespace Kamek.Commands
 
                 switch (ValueType)
                 {
-                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' original='{2:X2}' />", Address.Value, Value.Value, Original.Value.Value);
-                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' original='{2:X4}' />", Address.Value, Value.Value, Original.Value.Value);
+                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' original='{2:X2}' />", Address.Value.Value, Value.Value, Original.Value.Value);
+                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' original='{2:X4}' />", Address.Value.Value, Value.Value, Original.Value.Value);
                     case Type.Value32:
-                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' original='{2:X8}' />", Address.Value, Value.Value, Original.Value.Value);
+                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' original='{2:X8}' />", Address.Value.Value, Value.Value, Original.Value.Value);
                 }
             }
             else
             {
                 switch (ValueType)
                 {
-                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' />", Address.Value, Value.Value);
-                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' />", Address.Value, Value.Value);
+                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' />", Address.Value.Value, Value.Value);
+                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' />", Address.Value.Value, Value.Value);
                     case Type.Value32:
-                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value, Value.Value);
+                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value.Value, Value.Value);
                 }
             }
 
@@ -109,7 +109,7 @@ namespace Kamek.Commands
 
         public override IEnumerable<ulong> PackGeckoCodes()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             if (ValueType == Type.Pointer)
                 Value.AssertAbsolute();
             else
@@ -117,10 +117,10 @@ namespace Kamek.Commands
 
             if (Original.HasValue)
                 throw new NotImplementedException("conditional writes not yet supported for gecko");
-            if (Address.Value >= 0x90000000)
+            if (Address.Value.Value >= 0x90000000)
                 throw new NotImplementedException("MEM2 writes not yet supported for gecko");
 
-            ulong code = ((ulong)(Address.Value & 0x1FFFFFF) << 32) | Value.Value;
+            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | Value.Value;
             switch (ValueType)
             {
                 case Type.Value16: code |= 0x2000000UL << 32; break;
@@ -133,7 +133,7 @@ namespace Kamek.Commands
 
         public override void ApplyToDol(Dol dol)
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             if (ValueType == Type.Pointer)
                 Value.AssertAbsolute();
             else
@@ -145,14 +145,14 @@ namespace Kamek.Commands
                 switch (ValueType)
                 {
                     case Type.Value8:
-                        patchOK = (dol.ReadByte(Address.Value) == Original.Value.Value);
+                        patchOK = (dol.ReadByte(Address.Value.Value) == Original.Value.Value);
                         break;
                     case Type.Value16:
-                        patchOK = (dol.ReadUInt16(Address.Value) == Original.Value.Value);
+                        patchOK = (dol.ReadUInt16(Address.Value.Value) == Original.Value.Value);
                         break;
                     case Type.Value32:
                     case Type.Pointer:
-                        patchOK = (dol.ReadUInt32(Address.Value) == Original.Value.Value);
+                        patchOK = (dol.ReadUInt32(Address.Value.Value) == Original.Value.Value);
                         break;
                 }
                 if (!patchOK)
@@ -161,10 +161,10 @@ namespace Kamek.Commands
 
             switch (ValueType)
             {
-                case Type.Value8: dol.WriteByte(Address.Value, (byte)Value.Value); break;
-                case Type.Value16: dol.WriteUInt16(Address.Value, (ushort)Value.Value); break;
+                case Type.Value8: dol.WriteByte(Address.Value.Value, (byte)Value.Value); break;
+                case Type.Value16: dol.WriteUInt16(Address.Value.Value, (ushort)Value.Value); break;
                 case Type.Value32:
-                case Type.Pointer: dol.WriteUInt32(Address.Value, Value.Value); break;
+                case Type.Pointer: dol.WriteUInt32(Address.Value.Value, Value.Value); break;
             }
         }
 

--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -81,6 +81,7 @@ namespace Kamek
                 _symbolSizes.Add(pair.Key, pair.Value);
 
             AddRelocsAsCommands(linker.Fixups);
+
             foreach (var cmd in linker.Hooks)
                 ApplyHook(cmd);
             ApplyStaticCommands();
@@ -93,7 +94,10 @@ namespace Kamek
             {
                 if (_commands.ContainsKey(rel.source))
                     throw new InvalidOperationException(string.Format("duplicate commands for address {0}", rel.source));
-                _commands[rel.source] = new Commands.RelocCommand(rel.source, rel.dest, rel.type);
+                Commands.Command cmd = new Commands.RelocCommand(rel.source, rel.dest, rel.type);
+                cmd.CalculateAddress(this);
+                cmd.AssertAddressNonNull();
+                _commands[rel.source] = cmd;
             }
         }
 
@@ -103,9 +107,11 @@ namespace Kamek
             var hook = Hooks.Hook.Create(hookData, _mapper);
             foreach (var cmd in hook.Commands)
             {
-                if (_commands.ContainsKey(cmd.Address))
-                    throw new InvalidOperationException(string.Format("duplicate commands for address {0}", cmd.Address));
-                _commands[cmd.Address] = cmd;
+                cmd.CalculateAddress(this);
+                cmd.AssertAddressNonNull();
+                if (_commands.ContainsKey(cmd.Address.Value))
+                    throw new InvalidOperationException(string.Format("duplicate commands for address {0}", cmd.Address.Value));
+                _commands[cmd.Address.Value] = cmd;
             }
             _hooks.Add(hook);
         }
@@ -119,8 +125,10 @@ namespace Kamek
 
             foreach (var cmd in original.Values)
             {
-                if (!cmd.Apply(this))
-                    _commands[cmd.Address] = cmd;
+                if (!cmd.Apply(this)) {
+                    cmd.AssertAddressNonNull();
+                    _commands[cmd.Address.Value] = cmd;
+                }
             }
         }
 
@@ -141,20 +149,21 @@ namespace Kamek
 
                     foreach (var pair in _commands)
                     {
+                        pair.Value.AssertAddressNonNull();
                         uint cmdID = (uint)pair.Value.Id << 24;
-                        if (pair.Value.Address.IsRelative)
+                        if (pair.Value.Address.Value.IsRelative)
                         {
-                            if (pair.Value.Address.Value > 0xFFFFFF)
+                            if (pair.Value.Address.Value.Value > 0xFFFFFF)
                                 throw new InvalidOperationException("Address too high for packed command");
 
-                            cmdID |= pair.Value.Address.Value;
+                            cmdID |= pair.Value.Address.Value.Value;
                             bw.WriteBE(cmdID);
                         }
                         else
                         {
                             cmdID |= 0xFFFFFE;
                             bw.WriteBE(cmdID);
-                            bw.WriteBE(pair.Value.Address.Value);
+                            bw.WriteBE(pair.Value.Address.Value.Value);
                         }
                         pair.Value.WriteArguments(bw);
                     }


### PR DESCRIPTION
It was generating completely wrong data for the Kamek files.

Since `PatchExitCommand` needs a `KamekFile` in order to calculate its address, it needs to initialize its `Address` to `null` until a `KamekFile` becomes available later. Thus, a clean fix required making `Command.Address` nullable, which proceeded to affect the rest of the `Command` subclasses. I've added null checks where appropriate -- notably, not in subclasses which initialize `Address` from a non-nullable constructor parameter (i.e. all of them except `PatchExitCommand`).

I also added a virtual method `CalculateAddress()` that a `KamekFile` can call on `Command`s to ask them to calculate their actual address, since this has to happen earlier than in `Apply()`, which is where `PatchExitCommand` was previously doing that.