### PR TITLE
Add ctors support to kamekfiles and loader

### DIFF
--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -21,6 +21,8 @@ namespace Kamek
         private Word _baseAddress;
         private byte[] _codeBlob;
         private long _bssSize;
+        private long _ctorStart;
+        private long _ctorEnd;
 
         public Word BaseAddress { get { return _baseAddress; } }
         public byte[] CodeBlob { get { return _codeBlob; } }
@@ -72,6 +74,8 @@ namespace Kamek
 
             _baseAddress = linker.BaseAddress;
             _bssSize = linker.BssSize;
+            _ctorStart = linker.CtorStart - linker.OutputStart;
+            _ctorEnd = linker.CtorEnd - linker.OutputStart;
 
             _hooks = new List<Hooks.Hook>();
             _commands = new Dictionary<Word, Commands.Command>();
@@ -132,10 +136,14 @@ namespace Kamek
             {
                 using (var bw = new BinaryWriter(ms))
                 {
-                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\1'
-                    bw.WriteBE((uint)0x6B000001);
+                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\2'
+                    bw.WriteBE((uint)0x6B000002);
                     bw.WriteBE((uint)_bssSize);
                     bw.WriteBE((uint)_codeBlob.Length);
+                    bw.WriteBE((uint)_ctorStart);
+                    bw.WriteBE((uint)_ctorEnd);
+                    bw.WriteBE((uint)0);
+                    bw.WriteBE((uint)0);
 
                     bw.Write(_codeBlob);
 

--- a/loader/kamekLoader.cpp
+++ b/loader/kamekLoader.cpp
@@ -6,6 +6,9 @@ struct KBHeader {
 	u16 version;
 	u32 bssSize;
 	u32 codeSize;
+	u32 ctorStart;
+	u32 ctorEnd;
+	u32 _pad[2];
 };
 
 
@@ -133,13 +136,14 @@ void loadKamekBinary(const loaderFunctions *funcs, const void *binary, u32 binar
 	const KBHeader *header = (const KBHeader *)binary;
 	if (header->magic1 != 'Kame' || header->magic2 != 'k\0')
 		kamekError(funcs, "FATAL ERROR: Corrupted file, please check your game's Kamek files");
-	if (header->version != 1) {
+	if (header->version != 2) {
 		char err[512];
 		funcs->sprintf(err, "FATAL ERROR: Incompatible file (version %d), please upgrade your Kamek Loader", header->version);
 		kamekError(funcs, err);
 	}
 	
-	funcs->OSReport("header: bssSize=%u, codeSize=%u\n", header->bssSize, header->codeSize);
+	funcs->OSReport("header: bssSize=%u, codeSize=%u, ctors=%u-%u\n",
+		header->bssSize, header->codeSize, header->ctorStart, header->ctorEnd);
 
 	u32 textSize = header->codeSize + header->bssSize;
 	u32 text = (u32)funcs->kamekAlloc(textSize, true, funcs);
@@ -196,6 +200,11 @@ void loadKamekBinary(const loaderFunctions *funcs, const void *binary, u32 binar
 			sync
 			icbi r0, cacheAddr
 		}
+	}
+
+	typedef void (*Func)(void);
+	for (Func* f = (Func*)(text + header->ctorStart); f < (Func*)(text + header->ctorEnd); f++) {
+		(*f)();
 	}
 
 	__sync();


### PR DESCRIPTION
This patch makes the Kamek loader call the static init functions defined in the Kamek-file's ctors section. This is needed to support, for example, NSMBW actors that use states.

I had to add a couple new fields to the Kamek-file header to support this, so I bumped the version field up to 2. I also added 8 bytes of pad so the header length would be a nice 32 bytes instead of 24.