### PR TITLE
Fix Dolphin INI support

### DIFF
--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -33,7 +33,7 @@ namespace Kamek.Commands
 
         public override string PackForDolphin()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
             return string.Format("0x{0:X8}:dword:0x{1:X8}", Address.Value, GenerateInstruction());

--- a/Kamek/Commands/WriteCommand.cs
+++ b/Kamek/Commands/WriteCommand.cs
@@ -109,7 +109,7 @@ namespace Kamek.Commands
 
         public override string PackForDolphin()
         {
-            Address.AssertAbsolute();
+            Address.Value.AssertAbsolute();
             if (ValueType == Type.Pointer)
                 Value.AssertAbsolute();
             else


### PR DESCRIPTION
It wasn't rebased correctly and Kamek won't compile as-is