### PR TITLE
Add support for AR codes

### DIFF
--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -50,6 +50,17 @@ namespace Kamek.Commands
             return new ulong[1] { code };
         }
 
+        public override IEnumerable<ulong> PackActionReplayCodes()
+        {
+            Address.Value.AssertAbsolute();
+            Target.AssertAbsolute();
+
+            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | GenerateInstruction();
+            code |= 0x4000000UL << 32;
+
+            return new ulong[1] { code };
+        }
+
         public override bool Apply(KamekFile file)
         {
             if (Address.Value.IsAbsolute && Target.IsAbsolute && file.Contains(Address.Value))

--- a/Kamek/Commands/Command.cs
+++ b/Kamek/Commands/Command.cs
@@ -56,6 +56,7 @@ namespace Kamek.Commands
         public abstract string PackForRiivolution();
         public abstract string PackForDolphin();
         public abstract IEnumerable<ulong> PackGeckoCodes();
+        public abstract IEnumerable<ulong> PackActionReplayCodes();
         public abstract bool Apply(KamekFile file);
         public abstract void ApplyToDol(Dol dol);
 

--- a/Kamek/Commands/PatchExitCommand.cs
+++ b/Kamek/Commands/PatchExitCommand.cs
@@ -68,6 +68,11 @@ namespace Kamek.Commands
             throw new NotImplementedException();
         }
 
+        public override IEnumerable<ulong> PackActionReplayCodes()
+        {
+            throw new NotImplementedException();
+        }
+
         public override void ApplyToDol(Dol dol)
         {
             throw new NotImplementedException();

--- a/Kamek/Commands/RelocCommand.cs
+++ b/Kamek/Commands/RelocCommand.cs
@@ -38,6 +38,11 @@ namespace Kamek.Commands
             throw new NotImplementedException();
         }
 
+        public override IEnumerable<ulong> PackActionReplayCodes()
+        {
+            throw new NotImplementedException();
+        }
+
         public override void ApplyToDol(Dol dol)
         {
             Address.Value.AssertAbsolute();

--- a/Kamek/Commands/WriteCommand.cs
+++ b/Kamek/Commands/WriteCommand.cs
@@ -150,6 +150,49 @@ namespace Kamek.Commands
             return new ulong[1] { code };
         }
 
+        public override IEnumerable<ulong> PackActionReplayCodes()
+        {
+            Address.Value.AssertAbsolute();
+            if (ValueType == Type.Pointer)
+                Value.AssertAbsolute();
+            else
+                Value.AssertValue();
+
+            if (Address.Value.Value >= 0x90000000)
+                throw new NotImplementedException("MEM2 writes not yet supported for action replay");
+
+            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | Value.Value;
+            switch (ValueType)
+            {
+                case Type.Value16: code |= 0x2000000UL << 32; break;
+                case Type.Value32:
+                case Type.Pointer: code |= 0x4000000UL << 32; break;
+            }
+
+            if (Original.HasValue)
+            {
+                if (ValueType == Type.Pointer)
+                    Original.Value.AssertAbsolute();
+                else
+                    Original.Value.AssertValue();
+
+                ulong if_start = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | Original.Value.Value;
+                switch (ValueType)
+                {
+                    case Type.Value8:  if_start |= 0x08000000UL << 32; break;
+                    case Type.Value16: if_start |= 0x0A000000UL << 32; break;
+                    case Type.Value32:
+                    case Type.Pointer: if_start |= 0x0C000000UL << 32; break;
+                }
+
+                return new ulong[2] { if_start, code };
+            }
+            else
+            {
+                return new ulong[1] { code };
+            }
+        }
+
         public override void ApplyToDol(Dol dol)
         {
             Address.Value.AssertAbsolute();

--- a/Kamek/Program.cs
+++ b/Kamek/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,7 +18,7 @@ namespace Kamek
             // Parse the command line arguments and do cool things!
             var modules = new List<Elf>();
             uint? baseAddress = null;
-            string outputKamekPath = null, outputRiivPath = null, outputDolphinPath = null, outputGeckoPath = null, outputCodePath = null;
+            string outputKamekPath = null, outputRiivPath = null, outputDolphinPath = null, outputGeckoPath = null, outputARPath = null, outputCodePath = null;
             string inputDolPath = null, outputDolPath = null;
             var externals = new Dictionary<string, uint>();
             VersionInfo versions = null;
@@ -45,6 +45,8 @@ namespace Kamek
                         outputDolphinPath = arg.Substring(16);
                     else if (arg.StartsWith("-output-gecko="))
                         outputGeckoPath = arg.Substring(14);
+                    else if (arg.StartsWith("-output-ar="))
+                        outputARPath = arg.Substring(11);
                     else if (arg.StartsWith("-output-code="))
                         outputCodePath = arg.Substring(13);
                     else if (arg.StartsWith("-input-dol="))
@@ -82,7 +84,7 @@ namespace Kamek
                 Console.WriteLine("no input files specified");
                 return;
             }
-            if (outputKamekPath == null && outputRiivPath == null && outputDolphinPath == null && outputGeckoPath == null && outputCodePath == null && outputDolPath == null)
+            if (outputKamekPath == null && outputRiivPath == null && outputDolphinPath == null && outputGeckoPath == null && outputARPath == null && outputCodePath == null && outputDolPath == null)
             {
                 Console.WriteLine("no output path(s) specified");
                 return;
@@ -102,6 +104,7 @@ namespace Kamek
                 ambiguousOutputPath |= (outputRiivPath != null && !outputRiivPath.Contains("$KV$"));
                 ambiguousOutputPath |= (outputDolphinPath != null && !outputDolphinPath.Contains("$KV$"));
                 ambiguousOutputPath |= (outputGeckoPath != null && !outputGeckoPath.Contains("$KV$"));
+                ambiguousOutputPath |= (outputARPath != null && !outputARPath.Contains("$KV$"));
                 ambiguousOutputPath |= (outputCodePath != null && !outputCodePath.Contains("$KV$"));
                 ambiguousOutputPath |= (outputDolPath != null && !outputDolPath.Contains("$KV$"));
                 if (ambiguousOutputPath)
@@ -141,6 +144,8 @@ namespace Kamek
                     File.WriteAllText(outputDolphinPath.Replace("$KV$", version.Key), kf.PackDolphin());
                 if (outputGeckoPath != null)
                     File.WriteAllText(outputGeckoPath.Replace("$KV$", version.Key), kf.PackGeckoCodes());
+                if (outputARPath != null)
+                    File.WriteAllText(outputARPath.Replace("$KV$", version.Key), kf.PackActionReplayCodes());
                 if (outputCodePath != null)
                     File.WriteAllBytes(outputCodePath.Replace("$KV$", version.Key), kf.CodeBlob);
 
@@ -213,6 +218,8 @@ namespace Kamek
             Console.WriteLine("      write a Dolphin INI fragment (-static only)");
             Console.WriteLine("    -output-gecko=file.$KV$.xml");
             Console.WriteLine("      write a list of Gecko codes (-static only)");
+            Console.WriteLine("    -output-ar=file.$KV$.xml");
+            Console.WriteLine("      write a list of Action Replay codes (-static only)");
             Console.WriteLine("    -input-dol=file.$KV$.dol -output-dol=file2.$KV$.dol");
             Console.WriteLine("      apply these patches and generate a modified DOL (-static only)");
             Console.WriteLine("    -output-code=file.$KV$.bin");


### PR DESCRIPTION
This provides a relatively easy way to compile the Kamek loader for Dolphin versions predating its recent built-in Riivolution support. (Gecko codes don't work for that because Dolphin's codehandler conflicts with the Kamek loader in memory, whereas AR codes have no handler and are applied entirely in native code by the emulator.)