### PR TITLE
Change filenames expected by NSMBW loader

### DIFF
--- a/loader/nsmbw.cpp
+++ b/loader/nsmbw.cpp
@@ -151,9 +151,9 @@ int loadIntoNSMBW()
 
 	char path[64];
 	if (version == 0)
-		funcs->sprintf(path, "/engine.%c.bin", region);
+		funcs->sprintf(path, "/Code/%c.bin", region);
 	else
-		funcs->sprintf(path, "/engine.%c%d.bin", region, version);
+		funcs->sprintf(path, "/Code/%c%d.bin", region, version);
 	loadKamekBinaryFromDisc(funcs, path);
 
 	return 1;


### PR DESCRIPTION
Originally "/engine.{versioncode}.bin", now "/Code/{versioncode}.bin".

Some justifications for this change:

* Using a subfolder helps keep things cleaner than polluting the root directory.
* The word "engine" may (hotly contested) make sense for Newer's custom code, but using this term for *every* type of dynamic code patch doesn't really make sense. "Code" is an easily understood and uncontroversial term here.
    * Not every dynamic Kamek patch necessarily edits executable code (some may only edit data), so technically "code" isn't 100% accurate. But at the same time, the word "engine" doesn't apply to such patches, either, so "code" is no worse than the previous term in this regard. I don't think there's a better word you could use, anyway -- and if there is, it's probably not as simple, and easy to immediately understand.
* This *is* a backwards-incompatible change, but it only affects NSMBW Kamek mods specifically (not other games'), of which there are currently very few (most of them use Kamek 1.0). That's starting to change, though, as the Newer Team is planning on porting their past mods to this. So now is a great time to make this kind of change.
* "Code" is capitalized to be consistent with NSMBW's other top-level folder names.