### PR TITLE
Fix hooks in assembly files

### DIFF
--- a/k_stdlib/kamek_asm.S
+++ b/k_stdlib/kamek_asm.S
@@ -6,28 +6,43 @@ kctPatchExit .equ 5
 
 // general hook definition macros
 kmHook0: .macro type
-	.section ".kamek"
-	.long 0, type
+	.section .kamek
+	_kHook\@: .long 0, type
+	.previous
+	.section .discard
+	li r0, (_kHook\@)@l  // reference to prevent CodeWarrior from deleting the symbol
 	.previous
 	.endm
 kmHook1: .macro type, arg0
-	.section ".kamek"
-	.long 1, type, arg0
+	.section .kamek
+	_kHook\@: .long 1, type, arg0
+	.previous
+	.section .discard
+	li r0, (_kHook\@)@l  // reference to prevent CodeWarrior from deleting the symbol
 	.previous
 	.endm
 kmHook2: .macro type, arg0, arg1
-	.section ".kamek"
-	.long 2, type, arg0, arg1
+	.section .kamek
+	_kHook\@: .long 2, type, arg0, arg1
+	.previous
+	.section .discard
+	li r0, (_kHook\@)@l  // reference to prevent CodeWarrior from deleting the symbol
 	.previous
 	.endm
 kmHook3: .macro type, arg0, arg1, arg2
-	.section ".kamek"
-	.long 3, type, arg0, arg1, arg2
+	.section .kamek
+	_kHook\@: .long 3, type, arg0, arg1, arg2
+	.previous
+	.section .discard
+	li r0, (_kHook\@)@l  // reference to prevent CodeWarrior from deleting the symbol
 	.previous
 	.endm
 kmHook4: .macro type, arg0, arg1, arg2, arg3
-	.section ".kamek"
-	.long 4, type, arg0, arg1, arg2, arg3
+	.section .kamek
+	_kHook\@: .long 4, type, arg0, arg1, arg2, arg3
+	.previous
+	.section .discard
+	li r0, (_kHook\@)@l  // reference to prevent CodeWarrior from deleting the symbol
 	.previous
 	.endm
 


### PR DESCRIPTION
This PR fixes hooks in assembly files.

CodeWarrior's assembler deletes local labels that have no references to them, so hook symbols were being deleted. The ideal solution would be to tell CodeWarrior to preserve the symbols as exports with local binding, but there seems to be no way to do that. There are three possible solutions:

1) declare hooks as global symbols, even though they're not actually globally unique, and modify Kamek to accept these object files even though they're technically wrong

2) create dummy references to the symbols to prevent CodeWarrior from deleting them (kind of ugly, but produces object files that are technically correct, and therefore requires no changes to Kamek itself)

3) modify Kamek to read the .kamek section directly, without using symbols at all

I believe #2 is the best, since this is a CodeWarrior issue rather than a Kamek one, and it accordingly limits the "ugliness" to the compilation phase rather than the linking phase (wherein Kamek itself is doing nothing wrong).

This commit implements that by putting dummy references in a ".discard" section, which Kamek doesn't recognize and hence discards.