### PR TITLE
Trim published binaries

### DIFF
--- a/Kamek/Kamek.csproj
+++ b/Kamek/Kamek.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
*(and also fix a formatting mistake in the .csproj file)*

Suggested by @CLF78. This one-line project config change reduces the artifact sizes for each platform from ~61 MB to ~12 MB, which is a pretty huge improvement. The trimmed Linux binary seems to work fine, and I'd be surprised if this breaks either of the other two.