### PR TITLE
Loader QoL changes

### DIFF
--- a/loader/kamekLoader.cpp
+++ b/loader/kamekLoader.cpp
@@ -1,5 +1,9 @@
 #include "kamekLoader.h"
 
+#define KM_FILE_VERSION 2
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x) STRINGIFY_(x)
+
 struct KBHeader {
 	u32 magic1;
 	u16 magic2;
@@ -145,9 +149,11 @@ void loadKamekBinary(const loaderFunctions *funcs, const void *binary, u32 binar
 	const KBHeader *header = (const KBHeader *)binary;
 	if (header->magic1 != 'Kame' || header->magic2 != 'k\0')
 		kamekError(funcs, "FATAL ERROR: Corrupted file, please check your game's Kamek files");
-	if (header->version != 2) {
+	if (header->version != KM_FILE_VERSION) {
 		char err[512];
-		funcs->sprintf(err, "FATAL ERROR: Incompatible file (version %d), please upgrade your Kamek Loader", header->version);
+		funcs->sprintf(err, "FATAL ERROR: Incompatible file (version %d, expected " STRINGIFY(KM_FILE_VERSION) ");\nplease upgrade your Kamek %s",
+			header->version,
+			((header->version > KM_FILE_VERSION) ? "Loader" : "file"));
 		kamekError(funcs, err);
 	}
 	

--- a/loader/nsmbw.cpp
+++ b/loader/nsmbw.cpp
@@ -109,7 +109,12 @@ const loaderFunctionsEx functions_w = {
 void unknownVersion()
 {
 	// can't do much here!
-	// we can't output a message on screen without a valid OSFatal addr
+	// we can't output a message on screen without a valid OSFatal addr;
+	// all we can really do is set the screen to solid red before we die
+	// (note: Dolphin Emulator currently ignores this)
+	unsigned int *HW_VISOLID = (unsigned int*)0xcd000024;
+	*HW_VISOLID = 0x5aef5101;
+
 	for (;;);
 }
 


### PR DESCRIPTION
Two small improvements:

## Kamek file version detection

- The supported Kamek file version is now a constant at the top of the file, instead of buried in the code.
- If the Kamek file version doesn't match at runtime,
  - the error message now tells you the version it was expecting in addition to the one it found.
  - the error message now asks you to either update the loader *or* the file depending on which version was higher.

## NSMBW version detection failure

If the NSMBW loader can't detect the game version, it now sets `HW_VISOLID` to solid red before entering its infinite loop, as a hint as to what went wrong.

Dolphin unfortunately doesn't implement this register (maybe it will in the future?), but it does work on hardware (tested on Wii U). I think this is still worth including, in spite of that -- getting crash feedback in some environments is better than never getting it in any.