### PR TITLE
Fix Apply() logic in Command subclasses

### DIFF
--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -63,7 +63,9 @@ namespace Kamek.Commands
 
         public override bool Apply(KamekFile file)
         {
-            if (Address.Value.IsAbsolute && Target.IsAbsolute && file.Contains(Address.Value))
+            if (Address.Value.Type == file.BaseAddress.Type
+                    && file.Contains(Address.Value)
+                    && Address.Value.Type == Target.Type)
             {
                 file.WriteUInt32(Address.Value, GenerateInstruction());
                 return true;

--- a/Kamek/Commands/PatchExitCommand.cs
+++ b/Kamek/Commands/PatchExitCommand.cs
@@ -80,7 +80,9 @@ namespace Kamek.Commands
 
         public override bool Apply(KamekFile file)
         {
-            if (Address.Value.IsAbsolute && Target.IsAbsolute && file.Contains(Address.Value))
+            if (Address.Value.Type == file.BaseAddress.Type
+                    && file.Contains(Address.Value)
+                    && Address.Value.Type == Target.Type)
             {
                 file.WriteUInt32(Address.Value, GenerateInstruction());
                 return true;

--- a/Kamek/Commands/RelocCommand.cs
+++ b/Kamek/Commands/RelocCommand.cs
@@ -83,6 +83,9 @@ namespace Kamek.Commands
 
         public override bool Apply(KamekFile file)
         {
+            if (Address.Value.Type != file.BaseAddress.Type)
+                return false;
+
             switch (Id)
             {
                 case Ids.Rel24:


### PR DESCRIPTION
This PR improves some logic in `BranchCommand.Apply()`, making it possible to use `kmBranch()` and `kmCall()` to create a call from one game address to another (i.e. `kmCall(0xFROMADDR, 0xTOADDR)`). I also preemptively added similar logic to a couple other `Command` subclasses that make the same invalid assumptions. Fixes #28.

This only works for literal target addresses. Call targets defined as `extern`, as suggested by @CLF78 in the linked issue, seem to be a significantly more difficult challenge, as CodeWarrior throws a warning and generates a static initializer in this case. I think solving that would require changing the kstdlib headers in some way, at minimum.