### PR TITLE
update actions to be on latest versions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,8 +1,6 @@
-name: .NET
+name: Build with .NET
 
-on:
-  push:
-    branches: [ master ]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,8 @@
-name: Build with .NET
+name: .NET
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,9 +14,9 @@ jobs:
          - linux-x64
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: '6.0.x'
     - name: Build Kamek for ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
         cd %out%\%rid%
         rm *.pdb
         cp Kamek* ${{ github.workspace }}\build
-    - uses: actions/upload-artifact@v2.3.1
+    - uses: actions/upload-artifact@v3.1.2
       with:
         name: ${{ matrix.os }}
         path: ${{ github.workspace }}/build


### PR DESCRIPTION
Node.js 12 actions are deprecated so we should update them.
For reference see [Github's blogpost on the change.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)