### PR TITLE
Empty code blob bugs

### DIFF
--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -299,10 +299,6 @@ namespace Kamek
             var codes = new List<ulong>();
 
             // add the big patch
-            long paddingSize = 0;
-            if ((_codeBlob.Length % 8) != 0)
-                paddingSize = 8 - (_codeBlob.Length % 8);
-
             for (int i = 0; i < _codeBlob.Length; i += 4)
             {
                 ulong bits = 0x04000000UL << 32;


### PR DESCRIPTION
Fix bugs that occur with an empty code blob, as seen here:

```
<memory offset='0x80001900' value='' />
<memory offset='0x803B91BC' value='60000000' />
<memory offset='0x803B91C8' value='60000000' />
```