### PR TITLE
ALF support

### DIFF
--- a/Kamek/CodeFiles/Alf.cs
+++ b/Kamek/CodeFiles/Alf.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Kamek.CodeFiles
+{
+    class Alf : CodeFile
+    {
+        private const uint MAGIC = 0x464F4252;
+
+        public struct Symbol
+        {
+            public uint Address;
+            public uint Size;
+            public byte[] MangledName;
+            public byte[] DemangledName;
+            public bool IsData;
+            public uint? Unk10;
+        }
+
+        public struct Section : IComparable<Section>
+        {
+            public uint LoadAddress;
+            public uint Size;  // may be smaller than Data.Length, for bss
+            public byte[] Data;
+            public List<Symbol> Symbols;
+
+            public uint EndAddress { get { return (uint)(LoadAddress + Size); } }
+
+            public int CompareTo(Section other)
+            {
+                return (int)LoadAddress - (int)other.LoadAddress;
+            }
+        }
+
+        public uint Version;  // 104 or 105
+        public List<Section> Sections;
+        public uint EntryPoint;
+
+
+        public Alf(Stream input)
+        {
+            var br = new BinaryReader(input);
+
+            uint magic = br.ReadLittleUInt32();
+            Version = br.ReadLittleUInt32();
+            EntryPoint = br.ReadLittleUInt32();
+            uint numSections = br.ReadLittleUInt32();
+
+            if (magic != MAGIC)
+                throw new InvalidOperationException("wrong ALF magic");
+            if (Version != 104 && Version != 105)
+                throw new InvalidOperationException("unrecognized ALF version");
+
+            Sections = new List<Section>();
+
+            for (int i = 0; i < numSections; i++)
+            {
+                Section section = new Section();
+                section.LoadAddress = br.ReadLittleUInt32();
+                int storedSize = br.ReadLittleInt32();
+                section.Size = br.ReadLittleUInt32();
+                section.Data = br.ReadBytes(storedSize);
+                section.Symbols = new List<Symbol>();
+                Sections.Add(section);
+            }
+
+            br.ReadLittleUInt32();  // table size, ignored
+            uint numSymbols = br.ReadLittleUInt32();
+
+            for (int i = 0; i < numSymbols; i++)
+            {
+                Symbol symbol = new Symbol();
+
+                int mangledNameSize = br.ReadLittleInt32();
+                symbol.MangledName = br.ReadBytes(mangledNameSize);
+
+                int demangledNameSize = br.ReadLittleInt32();
+                symbol.DemangledName = br.ReadBytes(demangledNameSize);
+
+                symbol.Address = br.ReadLittleUInt32();
+                symbol.Size = br.ReadLittleUInt32();
+                symbol.IsData = br.ReadLittleUInt32() == 1;
+                int sectionID = br.ReadLittleInt32();
+
+                if (Version == 105)
+                    symbol.Unk10 = br.ReadLittleUInt32();
+                else
+                    symbol.Unk10 = null;
+
+                Sections[sectionID - 1].Symbols.Add(symbol);
+            }
+        }
+
+
+        public override void Write(Stream output)
+        {
+            var bw = new BinaryWriter(output);
+
+            // Header
+            bw.WriteLE(MAGIC);
+            bw.WriteLE(Version);
+            bw.WriteLE(EntryPoint);
+            bw.WriteLE((uint)Sections.Count);
+
+            // Sort the sections
+            Sections.Sort();
+
+            // Write all sections
+            foreach (var section in Sections)
+            {
+                bw.WriteLE(section.LoadAddress);
+                bw.WriteLE((uint)section.Data.Length);
+                bw.WriteLE(section.Size);
+                bw.Write(section.Data);
+            }
+
+            // Write the symbol table
+            long savedPosition = output.Position;
+            bw.WriteLE((uint)0);  // table size
+            bw.WriteLE((uint)0);  // total number of entries
+
+            int symbolCount = 0;
+            for (int i = 0; i < Sections.Count; i++)
+            {
+                Section section = Sections[i];
+
+                symbolCount += section.Symbols.Count;
+
+                foreach (var symbol in section.Symbols)
+                {
+                    bw.WriteLE((uint)symbol.MangledName.Length);
+                    bw.Write(symbol.MangledName);
+                    bw.WriteLE((uint)symbol.DemangledName.Length);
+                    bw.Write(symbol.DemangledName);
+                    bw.WriteLE(symbol.Address);
+                    bw.WriteLE(symbol.Size);
+                    bw.WriteLE((uint)(symbol.IsData ? 1 : 0));
+                    bw.WriteLE((uint)(i + 1));
+                    if (Version == 105)
+                        bw.WriteLE(symbol.Unk10.GetValueOrDefault());
+                }
+            }
+
+            // 8 extra null bytes for some reason -- don't know why ALF does this ¯\_(ツ)_/¯
+            bw.WriteLE((uint)0);
+            bw.WriteLE((uint)0);
+
+            long tableSize = output.Position - savedPosition - 4;
+            output.Position = savedPosition;
+            bw.WriteLE((uint)tableSize);
+            bw.WriteLE((uint)symbolCount);
+        }
+
+
+        public bool ResolveAddress(uint address, out int sectionID, out uint offset)
+        {
+            for (int i = 0; i < Sections.Count; i++)
+            {
+                if (address >= Sections[i].LoadAddress && address < Sections[i].EndAddress)
+                {
+                    sectionID = i;
+                    offset = address - Sections[i].LoadAddress;
+                    return true;
+                }
+            }
+
+            sectionID = -1;
+            offset = 0;
+            return false;
+        }
+
+
+        public override uint ReadUInt32(uint address)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            return Util.ExtractUInt32(Sections[sectionID].Data, offset);
+        }
+
+        public override void WriteUInt32(uint address, uint value)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            Util.InjectUInt32(Sections[sectionID].Data, offset, value);
+        }
+
+
+        public override ushort ReadUInt16(uint address)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            return Util.ExtractUInt16(Sections[sectionID].Data, offset);
+        }
+
+        public override void WriteUInt16(uint address, ushort value)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            Util.InjectUInt16(Sections[sectionID].Data, offset, value);
+        }
+
+
+        public override byte ReadByte(uint address)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            return Sections[sectionID].Data[offset];
+        }
+
+        public override void WriteByte(uint address, byte value)
+        {
+            int sectionID;
+            uint offset;
+            if (!ResolveAddress(address, out sectionID, out offset))
+                throw new InvalidOperationException("address out of range in ALF file");
+
+            Sections[sectionID].Data[offset] = value;
+        }
+    }
+}

--- a/Kamek/CodeFiles/CodeFile.cs
+++ b/Kamek/CodeFiles/CodeFile.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kamek.CodeFiles
+{
+    abstract class CodeFile
+    {
+        public abstract void Write(Stream output);
+        public abstract uint ReadUInt32(uint address);
+        public abstract void WriteUInt32(uint address, uint value);
+        public abstract ushort ReadUInt16(uint address);
+        public abstract void WriteUInt16(uint address, ushort value);
+        public abstract byte ReadByte(uint address);
+        public abstract void WriteByte(uint address, byte value);
+    }
+}

--- a/Kamek/CodeFiles/Dol.cs
+++ b/Kamek/CodeFiles/Dol.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.IO;
 
-namespace Kamek
+namespace Kamek.CodeFiles
 {
-    class Dol
+    class Dol : CodeFile
     {
         public struct Section
         {
@@ -45,7 +45,7 @@ namespace Kamek
         }
 
 
-        public void Write(Stream output)
+        public override void Write(Stream output)
         {
             var bw = new BinaryWriter(output);
 
@@ -101,7 +101,7 @@ namespace Kamek
         }
 
 
-        public uint ReadUInt32(uint address)
+        public override uint ReadUInt32(uint address)
         {
             int sectionID;
             uint offset;
@@ -111,7 +111,7 @@ namespace Kamek
             return Util.ExtractUInt32(Sections[sectionID].Data, offset);
         }
 
-        public void WriteUInt32(uint address, uint value)
+        public override void WriteUInt32(uint address, uint value)
         {
             int sectionID;
             uint offset;
@@ -122,7 +122,7 @@ namespace Kamek
         }
 
 
-        public ushort ReadUInt16(uint address)
+        public override ushort ReadUInt16(uint address)
         {
             int sectionID;
             uint offset;
@@ -132,7 +132,7 @@ namespace Kamek
             return Util.ExtractUInt16(Sections[sectionID].Data, offset);
         }
 
-        public void WriteUInt16(uint address, ushort value)
+        public override void WriteUInt16(uint address, ushort value)
         {
             int sectionID;
             uint offset;
@@ -143,7 +143,7 @@ namespace Kamek
         }
 
 
-        public byte ReadByte(uint address)
+        public override byte ReadByte(uint address)
         {
             int sectionID;
             uint offset;
@@ -153,7 +153,7 @@ namespace Kamek
             return Sections[sectionID].Data[offset];
         }
 
-        public void WriteByte(uint address, byte value)
+        public override void WriteByte(uint address, byte value)
         {
             int sectionID;
             uint offset;

--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -74,12 +74,12 @@ namespace Kamek.Commands
             return false;
         }
 
-        public override void ApplyToDol(Dol dol)
+        public override void ApplyToCodeFile(CodeFiles.CodeFile file)
         {
             Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
-            dol.WriteUInt32(Address.Value.Value, GenerateInstruction());
+            file.WriteUInt32(Address.Value.Value, GenerateInstruction());
         }
 
 

--- a/Kamek/Commands/Command.cs
+++ b/Kamek/Commands/Command.cs
@@ -58,7 +58,7 @@ namespace Kamek.Commands
         public abstract IEnumerable<ulong> PackGeckoCodes();
         public abstract IEnumerable<ulong> PackActionReplayCodes();
         public abstract bool Apply(KamekFile file);
-        public abstract void ApplyToDol(Dol dol);
+        public abstract void ApplyToCodeFile(CodeFiles.CodeFile file);
 
         public virtual void CalculateAddress(KamekFile file) {}
 

--- a/Kamek/Commands/PatchExitCommand.cs
+++ b/Kamek/Commands/PatchExitCommand.cs
@@ -73,7 +73,7 @@ namespace Kamek.Commands
             throw new NotImplementedException();
         }
 
-        public override void ApplyToDol(Dol dol)
+        public override void ApplyToCodeFile(CodeFiles.CodeFile file)
         {
             throw new NotImplementedException();
         }

--- a/Kamek/Commands/RelocCommand.cs
+++ b/Kamek/Commands/RelocCommand.cs
@@ -43,7 +43,7 @@ namespace Kamek.Commands
             throw new NotImplementedException();
         }
 
-        public override void ApplyToDol(Dol dol)
+        public override void ApplyToCodeFile(CodeFiles.CodeFile file)
         {
             Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
@@ -52,28 +52,28 @@ namespace Kamek.Commands
             {
                 case Ids.Rel24:
                     long delta = Target - Address.Value;
-                    uint insn = dol.ReadUInt32(Address.Value.Value) & 0xFC000003;
+                    uint insn = file.ReadUInt32(Address.Value.Value) & 0xFC000003;
                     insn |= ((uint)delta & 0x3FFFFFC);
-                    dol.WriteUInt32(Address.Value.Value, insn);
+                    file.WriteUInt32(Address.Value.Value, insn);
                     break;
 
                 case Ids.Addr32:
-                    dol.WriteUInt32(Address.Value.Value, Target.Value);
+                    file.WriteUInt32(Address.Value.Value, Target.Value);
                     break;
 
                 case Ids.Addr16Lo:
-                    dol.WriteUInt16(Address.Value.Value, (ushort)(Target.Value & 0xFFFF));
+                    file.WriteUInt16(Address.Value.Value, (ushort)(Target.Value & 0xFFFF));
                     break;
 
                 case Ids.Addr16Hi:
-                    dol.WriteUInt16(Address.Value.Value, (ushort)(Target.Value >> 16));
+                    file.WriteUInt16(Address.Value.Value, (ushort)(Target.Value >> 16));
                     break;
 
                 case Ids.Addr16Ha:
                     ushort v = (ushort)(Target.Value >> 16);
                     if ((Target.Value & 0x8000) == 0x8000)
                         v++;
-                    dol.WriteUInt16(Address.Value.Value, v);
+                    file.WriteUInt16(Address.Value.Value, v);
                     break;
 
                 default:

--- a/Kamek/Commands/WriteCommand.cs
+++ b/Kamek/Commands/WriteCommand.cs
@@ -249,7 +249,7 @@ namespace Kamek.Commands
             }
         }
 
-        public override void ApplyToDol(Dol dol)
+        public override void ApplyToCodeFile(CodeFiles.CodeFile file)
         {
             Address.Value.AssertAbsolute();
             if (ValueType == Type.Pointer)
@@ -263,14 +263,14 @@ namespace Kamek.Commands
                 switch (ValueType)
                 {
                     case Type.Value8:
-                        patchOK = (dol.ReadByte(Address.Value.Value) == Original.Value.Value);
+                        patchOK = (file.ReadByte(Address.Value.Value) == Original.Value.Value);
                         break;
                     case Type.Value16:
-                        patchOK = (dol.ReadUInt16(Address.Value.Value) == Original.Value.Value);
+                        patchOK = (file.ReadUInt16(Address.Value.Value) == Original.Value.Value);
                         break;
                     case Type.Value32:
                     case Type.Pointer:
-                        patchOK = (dol.ReadUInt32(Address.Value.Value) == Original.Value.Value);
+                        patchOK = (file.ReadUInt32(Address.Value.Value) == Original.Value.Value);
                         break;
                 }
                 if (!patchOK)
@@ -279,10 +279,10 @@ namespace Kamek.Commands
 
             switch (ValueType)
             {
-                case Type.Value8: dol.WriteByte(Address.Value.Value, (byte)Value.Value); break;
-                case Type.Value16: dol.WriteUInt16(Address.Value.Value, (ushort)Value.Value); break;
+                case Type.Value8: file.WriteByte(Address.Value.Value, (byte)Value.Value); break;
+                case Type.Value16: file.WriteUInt16(Address.Value.Value, (ushort)Value.Value); break;
                 case Type.Value32:
-                case Type.Pointer: dol.WriteUInt32(Address.Value.Value, Value.Value); break;
+                case Type.Pointer: file.WriteUInt32(Address.Value.Value, Value.Value); break;
             }
         }
 

--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -328,7 +328,7 @@ namespace Kamek
             return string.Join("\n", elements);
         }
 
-        public void InjectIntoDol(Dol dol)
+        public void InjectIntoDol(CodeFiles.Dol dol)
         {
             if (_baseAddress.Type == WordType.RelativeAddr)
                 throw new InvalidOperationException("cannot pack a dynamically linked binary into a DOL");
@@ -356,7 +356,37 @@ namespace Kamek
 
             // apply all patches
             foreach (var pair in _commands)
-                pair.Value.ApplyToDol(dol);
+                pair.Value.ApplyToCodeFile(dol);
+        }
+
+        public void InjectIntoAlf(CodeFiles.Alf alf)
+        {
+            if (_baseAddress.Type == WordType.RelativeAddr)
+                throw new InvalidOperationException("cannot pack a dynamically linked binary into an ALF");
+
+            if (_codeBlob.Length > 0)
+            {
+                CodeFiles.Alf.Section codeSection = new CodeFiles.Alf.Section();
+                codeSection.LoadAddress = _baseAddress.Value;
+                codeSection.Size = (uint)_codeBlob.Length;
+                codeSection.Data = _codeBlob;
+                codeSection.Symbols = new List<CodeFiles.Alf.Symbol>();
+                alf.Sections.Add(codeSection);
+            }
+
+            if (_bssSize > 0)
+            {
+                CodeFiles.Alf.Section bssSection = new CodeFiles.Alf.Section();
+                bssSection.LoadAddress = (uint)(_baseAddress.Value + _codeBlob.Length);
+                bssSection.Size = (uint)_bssSize;
+                bssSection.Data = new byte[0];
+                bssSection.Symbols = new List<CodeFiles.Alf.Symbol>();
+                alf.Sections.Add(bssSection);
+            }
+
+            // apply all patches
+            foreach (var pair in _commands)
+                pair.Value.ApplyToCodeFile(alf);
         }
     }
 }

--- a/Kamek/Util.cs
+++ b/Kamek/Util.cs
@@ -16,11 +16,25 @@ namespace Kamek
             return (ushort)((a << 8) | b);
         }
 
+        public static ushort ReadLittleUInt16(this BinaryReader br)
+        {
+            byte a = br.ReadByte();
+            byte b = br.ReadByte();
+            return (ushort)((b << 8) | a);
+        }
+
         public static uint ReadBigUInt32(this BinaryReader br)
         {
             ushort a = br.ReadBigUInt16();
             ushort b = br.ReadBigUInt16();
             return (uint)((a << 16) | b);
+        }
+
+        public static uint ReadLittleUInt32(this BinaryReader br)
+        {
+            ushort a = br.ReadLittleUInt16();
+            ushort b = br.ReadLittleUInt16();
+            return (uint)((b << 16) | a);
         }
 
         public static int ReadBigInt32(this BinaryReader br)
@@ -30,16 +44,35 @@ namespace Kamek
             return (int)((a << 16) | b);
         }
 
+        public static int ReadLittleInt32(this BinaryReader br)
+        {
+            ushort a = br.ReadLittleUInt16();
+            ushort b = br.ReadLittleUInt16();
+            return (int)((b << 16) | a);
+        }
+
         public static void WriteBE(this BinaryWriter bw, ushort value)
         {
             bw.Write((byte)(value >> 8));
             bw.Write((byte)(value & 0xFF));
         }
 
+        public static void WriteLE(this BinaryWriter bw, ushort value)
+        {
+            bw.Write((byte)(value & 0xFF));
+            bw.Write((byte)(value >> 8));
+        }
+
         public static void WriteBE(this BinaryWriter bw, uint value)
         {
             bw.WriteBE((ushort)(value >> 16));
             bw.WriteBE((ushort)(value & 0xFFFF));
+        }
+
+        public static void WriteLE(this BinaryWriter bw, uint value)
+        {
+            bw.WriteLE((ushort)(value & 0xFFFF));
+            bw.WriteLE((ushort)(value >> 16));
         }
 
 


### PR DESCRIPTION
This PR adds support for the ALF file format found in the Lingcod-emulated Chinese Nvidia Shield Nintendo game releases from 2017-2019. File format versions 104 (NSMBW, Twilight Princess, Punch-Out) and 105 (Super Mario Galaxy, Donkey Kong Country Returns) are both supported.

Ignoring the surface-level structural changes, ALF has a few semantic differences from DOL:

- A symbol table is included. In retail releases, these are djb2a hashes of strings (e.g. `#1D04F9FB`) instead of the original strings (`lingcod_callNVSISnippet`).
- Executability of sections isn't indicated.
- bss sections are listed individually instead of as a single combined area.

None of these really pose any problems for Kamek, though the symbol table raises a design question: should symbols from the newly injected code be added to it? Currently this isn't done, but this could potentially be changed in the future.

Implementation-wise, I moved the `Dol` class into a new `CodeFiles` namespace, and created an abstract parent class `CodeFile` for it, which the new `Alf` class also inherits. Most methods that took `Dol` as a parameter now take `CodeFile` instead. The exception is `KamekFile.InjectIntoDol`/`KamekFile.InjectIntoAlf`, since the logic for adding new sections to DOL vs. ALF is significantly different.