### PR TITLE
Generate Riivolution XMLs with double quotes, not single quotes

### DIFF
--- a/Kamek/Commands/BranchCommand.cs
+++ b/Kamek/Commands/BranchCommand.cs
@@ -28,7 +28,7 @@ namespace Kamek.Commands
             Address.Value.AssertAbsolute();
             Target.AssertAbsolute();
 
-            return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value.Value, GenerateInstruction());
+            return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X8}\" />", Address.Value.Value, GenerateInstruction());
         }
 
         public override string PackForDolphin()

--- a/Kamek/Commands/WriteCommand.cs
+++ b/Kamek/Commands/WriteCommand.cs
@@ -87,20 +87,20 @@ namespace Kamek.Commands
 
                 switch (ValueType)
                 {
-                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' original='{2:X2}' />", Address.Value.Value, Value.Value, Original.Value.Value);
-                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' original='{2:X4}' />", Address.Value.Value, Value.Value, Original.Value.Value);
+                    case Type.Value8: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X2}\" original=\"{2:X2}\" />", Address.Value.Value, Value.Value, Original.Value.Value);
+                    case Type.Value16: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X4}\" original=\"{2:X4}\" />", Address.Value.Value, Value.Value, Original.Value.Value);
                     case Type.Value32:
-                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' original='{2:X8}' />", Address.Value.Value, Value.Value, Original.Value.Value);
+                    case Type.Pointer: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X8}\" original=\"{2:X8}\" />", Address.Value.Value, Value.Value, Original.Value.Value);
                 }
             }
             else
             {
                 switch (ValueType)
                 {
-                    case Type.Value8: return string.Format("<memory offset='0x{0:X8}' value='{1:X2}' />", Address.Value.Value, Value.Value);
-                    case Type.Value16: return string.Format("<memory offset='0x{0:X8}' value='{1:X4}' />", Address.Value.Value, Value.Value);
+                    case Type.Value8: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X2}\" />", Address.Value.Value, Value.Value);
+                    case Type.Value16: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X4}\" />", Address.Value.Value, Value.Value);
                     case Type.Value32:
-                    case Type.Pointer: return string.Format("<memory offset='0x{0:X8}' value='{1:X8}' />", Address.Value.Value, Value.Value);
+                    case Type.Pointer: return string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X8}\" />", Address.Value.Value, Value.Value);
                 }
             }
 

--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -196,7 +196,7 @@ namespace Kamek
                 for (int i = 0; i < _codeBlob.Length; i++)
                     sb.AppendFormat("{0:X2}", _codeBlob[i]);
 
-                elements.Add(string.Format("<memory offset='0x{0:X8}' value='{1}' />", _baseAddress.Value, sb.ToString()));
+                elements.Add(string.Format("<memory offset=\"0x{0:X8}\" value=\"{1}\" />", _baseAddress.Value, sb.ToString()));
             }
 
             // add individual patches


### PR DESCRIPTION
Single quotes don't prevent the XML from working as far as I know, but I find myself changing them to double quotes manually every time _anyway_ to be consistent with my own XMLs and pretty much every other XML written for Riivolution out there, too. It's quite obnoxious.

So I think this is a small but not insubstantial quality of life improvement.