### PR TITLE
Support Riivolution XML and Dolphin INI templates

### DIFF
--- a/Kamek/KamekFile.cs
+++ b/Kamek/KamekFile.cs
@@ -372,13 +372,13 @@ namespace Kamek
             }
             else
             {
-                int placeholderIndex = template.IndexOf("$KX$");
+                int placeholderIndex = template.IndexOf("$KF$");
                 if (placeholderIndex == -1)
-                    throw new InvalidDataException(string.Format("\"$KX$\" placeholder not found in {0} template", formatName));
-                if (template.IndexOf("$KX$", placeholderIndex + 1) != -1)
-                    throw new InvalidDataException(string.Format("multiple \"$KX$\" placeholders found in {0} template", formatName));
+                    throw new InvalidDataException(string.Format("\"$KF$\" placeholder not found in {0} template", formatName));
+                if (template.IndexOf("$KF$", placeholderIndex + 1) != -1)
+                    throw new InvalidDataException(string.Format("multiple \"$KF$\" placeholders found in {0} template", formatName));
 
-                // If the line containing $KX$ has only whitespace before it,
+                // If the line containing $KF$ has only whitespace before it,
                 // we can use that as indentation for all of our new lines.
                 // Otherwise, be conservative and don't do that.
 
@@ -393,7 +393,7 @@ namespace Kamek
                     joinString = "\n" + placeholderLineStart;
                 }
 
-                return template.Replace("$KX$", string.Join(joinString, lines));
+                return template.Replace("$KF$", string.Join(joinString, lines));
             }
         }
     }

--- a/Kamek/Program.cs
+++ b/Kamek/Program.cs
@@ -290,11 +290,11 @@ namespace Kamek
             Console.WriteLine("  Output Configuration:");
             Console.WriteLine("    -input-riiv=file.$KV$.xml");
             Console.WriteLine("      if -output-riiv is used, use this file as a template, where");
-            Console.WriteLine("      the magic string \"$KX$\" will be replaced by the new XML tags.");
+            Console.WriteLine("      the magic string \"$KF$\" will be replaced by the new XML tags.");
             Console.WriteLine("      otherwise, the new XML tags will be emitted by themselves");
             Console.WriteLine("    -input-dolphin=file.$KV$.ini");
             Console.WriteLine("      if -output-dolphin is used, use this file as a template, where");
-            Console.WriteLine("      the magic string \"$KX$\" will be replaced by the new INI lines.");
+            Console.WriteLine("      the magic string \"$KF$\" will be replaced by the new INI lines.");
             Console.WriteLine("      otherwise, the new INI lines will be emitted by themselves");
             Console.WriteLine("    -valuefile=loader.bin");
             Console.WriteLine("      if -output-riiv is used, emit a \"valuefile\" attribute containing this path string, instead of \"value\"");

--- a/Kamek/Program.cs
+++ b/Kamek/Program.cs
@@ -33,7 +33,7 @@ namespace Kamek
             // Parse the command line arguments and do cool things!
             var modules = new List<Elf>();
             uint? baseAddress = null;
-            string outputKamekPath = null, outputRiivPath = null, outputDolphinPath = null, outputGeckoPath = null, outputARPath = null, outputCodePath = null;
+            string outputKamekPath = null, inputRiivPath = null, outputRiivPath = null, outputDolphinPath = null, outputGeckoPath = null, outputARPath = null, outputCodePath = null;
             string inputDolPath = null, outputDolPath = null;
             string outputMapPath = null;
             var externals = new Dictionary<string, uint>();
@@ -56,6 +56,8 @@ namespace Kamek
                         baseAddress = uint.Parse(arg.Substring(10), System.Globalization.NumberStyles.HexNumber);
                     else if (arg.StartsWith("-output-kamek="))
                         outputKamekPath = arg.Substring(14);
+                    else if (arg.StartsWith("-input-riiv="))
+                        inputRiivPath = arg.Substring(12);
                     else if (arg.StartsWith("-output-riiv="))
                         outputRiivPath = arg.Substring(13);
                     else if (arg.StartsWith("-output-dolphin="))
@@ -170,7 +172,12 @@ namespace Kamek
                 if (outputKamekPath != null)
                     File.WriteAllBytes(outputKamekPath.Replace("$KV$", version.Key), kf.Pack());
                 if (outputRiivPath != null)
-                    File.WriteAllText(outputRiivPath.Replace("$KV$", version.Key), kf.PackRiivolution(valuefilePath));
+                {
+                    string inputRiivData = null;
+                    if (inputRiivPath != null)
+                        inputRiivData = File.ReadAllText(inputRiivPath.Replace("$KV$", version.Key));
+                    File.WriteAllText(outputRiivPath.Replace("$KV$", version.Key), kf.PackRiivolution(inputRiivData, valuefilePath));
+                }
                 if (outputDolphinPath != null)
                     File.WriteAllText(outputDolphinPath.Replace("$KV$", version.Key), kf.PackDolphin());
                 if (outputGeckoPath != null)


### PR DESCRIPTION
This PR adds `-input-riiv=file.xml` and `-input-dolphin=file.ini` arguments for Riivolution XML and Dolphin INI "templates."

Previously, Kamek could only produce XML/INI _fragments_ as output, not full files. Incorporating these fragments into the actual XML/INI files was left entirely to the user. Not very difficult, but still a manual step that had to be done.

This PR improves the situation by adding new CLI arguments for file _templates_, where the magic placeholder string `$KF$` ("Kamek Fragment", similar to the `$KV$` "Kamek Version" placeholder respected in certain input/output filenames) will be replaced with the output data fragment.

The implementation is pretty simple, aside from a bit of somewhat-fancy logic to detect and mimic indentation found in the template. (Specifically: if all characters to the left of the placeholder are whitespace, they're copied to the start of each new line added to the file.)