### PR TITLE
kmWriteDef* (Injection)

### DIFF
--- a/Source/Commands/Command.cs
+++ b/Source/Commands/Command.cs
@@ -29,6 +29,7 @@ namespace Kamek.Commands
             CondWrite32 = 36,
             CondWrite16 = 37,
             CondWrite8 = 38,
+            WriteRange = 39,
 
             Branch = 64,
             BranchLink = 65,

--- a/Source/Commands/WriteRangeCommand.cs
+++ b/Source/Commands/WriteRangeCommand.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kamek.Commands
+{
+    class WriteRangeCommand : Command
+    {
+        public readonly byte[] Value;
+
+        public WriteRangeCommand(Word address, byte[] value)
+            : base(Command.Ids.WriteRange, address)
+        {
+            Value = value;
+        }
+
+        public override void WriteArguments(BinaryWriter bw)
+        {
+            AssertValue();
+
+            // Format (after the address):
+            // - u32 length
+            // - data, aligned so that you can do efficient 32-bit copies
+            //   - Example: dest. addr 0x80800000 -> no padding between "length" and data blob
+            //   - Example: dest. addr 0x80800003 -> data blob will be prefixed by 3 null pad bytes,
+            //     so you can copy that single byte and then do 32-bit copies from 0x80800004 onward
+            // - Additional pad bytes, if needed to align the next command to 4
+
+            bw.WriteBE((uint)Value.Length);
+
+            // Align to 4 (start)
+            if (Address.Value.Value % 4 == 1)
+                bw.Write(new byte[] {0});
+            else if (Address.Value.Value % 4 == 2)
+                bw.Write(new byte[] {0, 0});
+            else if (Address.Value.Value % 4 == 3)
+                bw.Write(new byte[] {0, 0, 0});
+
+            bw.Write(Value);
+
+            // Align to 4 (end)
+            if ((Address.Value.Value + Value.Length) % 4 == 1)
+                bw.Write(new byte[] {0, 0, 0});
+            else if ((Address.Value.Value + Value.Length) % 4 == 2)
+                bw.Write(new byte[] {0, 0});
+            else if ((Address.Value.Value + Value.Length) % 4 == 3)
+                bw.Write(new byte[] {0});
+        }
+
+        public override IEnumerable<string> PackForRiivolution()
+        {
+            Address.Value.AssertAbsolute();
+            AssertValue();
+
+            return Util.PackLargeWriteForRiivolution(Address.Value, Value);
+        }
+
+        public override IEnumerable<string> PackForDolphin()
+        {
+            Address.Value.AssertAbsolute();
+            AssertValue();
+
+            return Util.PackLargeWriteForDolphin(Address.Value, Value);
+        }
+
+        public override IEnumerable<ulong> PackGeckoCodes()
+        {
+            Address.Value.AssertAbsolute();
+            AssertValue();
+
+            if (Address.Value.Value >= 0x90000000)
+                throw new NotImplementedException("MEM2 writes not yet supported for gecko");
+
+            return Util.PackLargeWriteForGeckoCodes(Address.Value, Value);
+        }
+
+        public override IEnumerable<ulong> PackActionReplayCodes()
+        {
+            Address.Value.AssertAbsolute();
+            AssertValue();
+
+            if (Address.Value.Value >= 0x90000000)
+                throw new NotImplementedException("MEM2 writes not yet supported for action replay");
+
+            return Util.PackLargeWriteForActionReplayCodes(Address.Value, Value);
+        }
+
+        public override void ApplyToCodeFile(CodeFiles.CodeFile file)
+        {
+            Address.Value.AssertAbsolute();
+            AssertValue();
+
+            for (uint offs = 0; offs < Value.Length; offs++)
+                file.WriteByte(Address.Value.Value + offs, Value[offs]);
+        }
+
+        public override bool Apply(KamekFile file)
+        {
+            return false;
+        }
+
+        private void AssertValue()
+        {
+            if (Value.Length == 0)
+                throw new InvalidOperationException("WriteRangeCommand has no data to write");
+        }
+    }
+}

--- a/Source/Commands/WriteWordCommand.cs
+++ b/Source/Commands/WriteWordCommand.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Kamek.Commands
 {
-    class WriteCommand : Command
+    class WriteWordCommand : Command
     {
         public enum Type
         {
@@ -49,7 +49,7 @@ namespace Kamek.Commands
         public readonly Word Value;
         public readonly Word? Original;
 
-        public WriteCommand(Word address, Word value, Type valueType, Word? original)
+        public WriteWordCommand(Word address, Word value, Type valueType, Word? original)
             : base(IdFromType(valueType, original.HasValue), address)
         {
             Value = value;

--- a/Source/Hooks/WriteHook.cs
+++ b/Source/Hooks/WriteHook.cs
@@ -13,18 +13,18 @@ namespace Kamek.Hooks
         public WriteHook(bool isConditional, Word[] args, AddressMapper mapper)
         {
             if (args.Length != (isConditional ? 4 : 3))
-                throw new InvalidDataException("wrong arg count for WriteCommand");
+                throw new InvalidDataException("wrong arg count for WriteWordCommand");
 
             // expected args:
             //   address  : pointer to game code
             //   value    : value, OR pointer to game code or to Kamek code
             //   original : value, OR pointer to game code or to Kamek code
-            var type = (WriteCommand.Type)GetValueArg(args[0]).Value;
+            var type = (WriteWordCommand.Type)GetValueArg(args[0]).Value;
             Word address, value;
             Word? original = null;
 
             address = GetAbsoluteArg(args[1], mapper);
-            if (type == WriteCommand.Type.Pointer)
+            if (type == WriteWordCommand.Type.Pointer)
             {
                 value = GetAnyPointerArg(args[2], mapper);
                 if (isConditional)
@@ -37,7 +37,7 @@ namespace Kamek.Hooks
                     original = GetValueArg(args[3]);
             }
 
-            Commands.Add(new WriteCommand(address, value, type, original));
+            Commands.Add(new WriteWordCommand(address, value, type, original));
         }
     }
 }

--- a/Source/KamekFile.cs
+++ b/Source/KamekFile.cs
@@ -18,37 +18,76 @@ namespace Kamek
 
 
 
+        public struct InjectedCodeBlob
+        {
+            public uint Address;
+            public byte[] Data;
+        }
+
         private Word _baseAddress;
         private byte[] _codeBlob;
+        private List<InjectedCodeBlob> _injectedCodeBlobs;
         private long _bssSize;
         private long _ctorStart;
         private long _ctorEnd;
 
         public Word BaseAddress { get { return _baseAddress; } }
         public byte[] CodeBlob { get { return _codeBlob; } }
+        public IReadOnlyList<InjectedCodeBlob> InjectedCodeBlobs { get { return _injectedCodeBlobs; } }
 
         #region Result Binary Manipulation
+        private InjectedCodeBlob? FindInjectedBlobForAddr(Word addr, uint accessSize)
+        {
+            if (addr.Type == WordType.AbsoluteAddr)
+                foreach (var blob in _injectedCodeBlobs)
+                    if (blob.Address <= addr.Value && addr.Value + accessSize <= blob.Address + blob.Data.Length)
+                        return blob;
+            return null;
+        }
+
         public ushort ReadUInt16(Word addr)
         {
-            return Util.ExtractUInt16(_codeBlob, addr - _baseAddress);
+            InjectedCodeBlob? blob = FindInjectedBlobForAddr(addr, 2);
+            if (blob != null)
+                return Util.ExtractUInt16(blob.Value.Data, addr.Value - blob.Value.Address);
+            else
+                return Util.ExtractUInt16(_codeBlob, addr - _baseAddress);
         }
         public uint ReadUInt32(Word addr)
         {
-            return Util.ExtractUInt32(_codeBlob, addr - _baseAddress);
+            InjectedCodeBlob? blob = FindInjectedBlobForAddr(addr, 4);
+            if (blob != null)
+                return Util.ExtractUInt32(blob.Value.Data, addr.Value - blob.Value.Address);
+            else
+                return Util.ExtractUInt32(_codeBlob, addr - _baseAddress);
         }
         public void WriteUInt16(Word addr, ushort value)
         {
-            Util.InjectUInt16(_codeBlob, addr - _baseAddress, value);
+            InjectedCodeBlob? blob = FindInjectedBlobForAddr(addr, 2);
+            if (blob != null)
+                Util.InjectUInt16(blob.Value.Data, addr.Value - blob.Value.Address, value);
+            else
+                Util.InjectUInt16(_codeBlob, addr - _baseAddress, value);
         }
         public void WriteUInt32(Word addr, uint value)
         {
-            Util.InjectUInt32(_codeBlob, addr - _baseAddress, value);
+            InjectedCodeBlob? blob = FindInjectedBlobForAddr(addr, 4);
+            if (blob != null)
+                Util.InjectUInt32(blob.Value.Data, addr.Value - blob.Value.Address, value);
+            else
+                Util.InjectUInt32(_codeBlob, addr - _baseAddress, value);
         }
 
         public bool Contains(Word addr)
         {
+            if (addr.Type == WordType.AbsoluteAddr)
+                foreach (var blob in _injectedCodeBlobs)
+                    if (blob.Address <= addr.Value && addr.Value < blob.Address + blob.Data.Length)
+                        return true;
+
             if (addr.Type != _baseAddress.Type)
                 return false;
+
             return (addr >= _baseAddress && addr < (_baseAddress + _codeBlob.Length));
         }
 
@@ -58,7 +97,11 @@ namespace Kamek
         }
         #endregion
 
-        private Dictionary<Word, Commands.Command> _commands;
+        private Dictionary<Word, Commands.Command> _injectionCommands;
+        private Dictionary<Word, Commands.Command> _otherCommands;
+        // Injection commands have to come first, since relocations are applied on top of them
+        public IEnumerable<KeyValuePair<Word, Commands.Command>> _commands { get { return _injectionCommands.Concat(_otherCommands); } }
+
         private List<Hooks.Hook> _hooks;
         private Dictionary<Word, uint> _symbolSizes;
         private AddressMapper _mapper;
@@ -74,13 +117,23 @@ namespace Kamek
             _codeBlob = new byte[linker.OutputEnd - linker.OutputStart];
             Array.Copy(linker.Memory, linker.OutputStart - linker.BaseAddress, _codeBlob, 0, _codeBlob.Length);
 
+            _injectedCodeBlobs = new List<InjectedCodeBlob>();
+
+            foreach (var injection in linker.InjectedSections)
+            {
+                byte[] data = new byte[injection.Data.Length];
+                Array.Copy(injection.Data, 0, data, 0, injection.Data.Length);
+                _injectedCodeBlobs.Add(new InjectedCodeBlob { Address=injection.Address, Data=data });
+            }
+
             _baseAddress = linker.BaseAddress;
             _bssSize = linker.BssSize;
             _ctorStart = linker.CtorStart - linker.OutputStart;
             _ctorEnd = linker.CtorEnd - linker.OutputStart;
 
             _hooks = new List<Hooks.Hook>();
-            _commands = new Dictionary<Word, Commands.Command>();
+            _injectionCommands = new Dictionary<Word, Commands.Command>();
+            _otherCommands = new Dictionary<Word, Commands.Command>();
 
             _symbolSizes = new Dictionary<Word, uint>();
             foreach (var pair in linker.SymbolSizes)
@@ -91,6 +144,8 @@ namespace Kamek
             foreach (var cmd in linker.Hooks)
                 ApplyHook(cmd);
             ApplyStaticCommands();
+
+            AddInjectionsAsCommands();
         }
 
 
@@ -98,12 +153,12 @@ namespace Kamek
         {
             foreach (var rel in relocs)
             {
-                if (_commands.ContainsKey(rel.source))
+                if (_otherCommands.ContainsKey(rel.source))
                     throw new InvalidOperationException(string.Format("duplicate commands for address {0}", rel.source));
                 Commands.Command cmd = new Commands.RelocCommand(rel.source, rel.dest, rel.type);
                 cmd.CalculateAddress(this);
                 cmd.AssertAddressNonNull();
-                _commands[rel.source] = cmd;
+                _otherCommands[rel.source] = cmd;
             }
         }
 
@@ -115,9 +170,9 @@ namespace Kamek
             {
                 cmd.CalculateAddress(this);
                 cmd.AssertAddressNonNull();
-                if (_commands.ContainsKey(cmd.Address.Value))
+                if (_otherCommands.ContainsKey(cmd.Address.Value))
                     throw new InvalidOperationException(string.Format("duplicate commands for address {0}", cmd.Address.Value));
-                _commands[cmd.Address.Value] = cmd;
+                _otherCommands[cmd.Address.Value] = cmd;
             }
             _hooks.Add(hook);
         }
@@ -125,16 +180,30 @@ namespace Kamek
 
         private void ApplyStaticCommands()
         {
-            // leave _commands containing just the ones we couldn't apply here
-            var original = _commands;
-            _commands = new Dictionary<Word, Commands.Command>();
+            // leave _otherCommands containing just the ones we couldn't apply here
+            var original = _otherCommands;
+            _otherCommands = new Dictionary<Word, Commands.Command>();
 
             foreach (var cmd in original.Values)
             {
-                if (!cmd.Apply(this)) {
+                if (!cmd.Apply(this))
+                {
                     cmd.AssertAddressNonNull();
-                    _commands[cmd.Address.Value] = cmd;
+                    _otherCommands[cmd.Address.Value] = cmd;
                 }
+            }
+        }
+
+
+        private void AddInjectionsAsCommands()
+        {
+            foreach (var blob in _injectedCodeBlobs)
+            {
+                var addr = new Word(WordType.AbsoluteAddr, blob.Address);
+                Commands.WriteRangeCommand cmd = new Commands.WriteRangeCommand(addr, blob.Data);
+                cmd.CalculateAddress(this);
+                cmd.AssertAddressNonNull();
+                _injectionCommands[cmd.Address.Value] = cmd;
             }
         }
 
@@ -146,8 +215,8 @@ namespace Kamek
             {
                 using (var bw = new BinaryWriter(ms))
                 {
-                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\2'
-                    bw.WriteBE((uint)0x6B000002);
+                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\3'
+                    bw.WriteBE((uint)0x6B000003);
                     bw.WriteBE((uint)_bssSize);
                     bw.WriteBE((uint)_codeBlob.Length);
                     bw.WriteBE((uint)_ctorStart);

--- a/Source/Linker.cs
+++ b/Source/Linker.cs
@@ -62,7 +62,6 @@ namespace Kamek
         private Word _dataStart, _dataEnd;
         private Word _outputStart, _outputEnd;
         private Word _bssStart, _bssEnd;
-        private Word _kamekStart, _kamekEnd;
         private byte[] _memory = null;
 
         public Word BaseAddress { get { return _baseAddress; } }
@@ -76,6 +75,7 @@ namespace Kamek
 
         #region Collecting Sections
         private Dictionary<Elf.ElfSection, Word> _sectionBases = new Dictionary<Elf.ElfSection, Word>();
+        private List<Elf.ElfSection> _hookSections = new List<Elf.ElfSection>();
 
         private void ImportSections(ref List<byte[]> blobs, ref Word location, string prefix)
         {
@@ -102,6 +102,15 @@ namespace Kamek
                     }
                 }
             }
+        }
+
+        private void ImportHookSections()
+        {
+            foreach (var elf in _modules)
+                foreach (var s in (from s in elf.Sections
+                                   where s.name.StartsWith(".kamek")
+                                   select s))
+                    _hookSections.Add(s);
         }
 
         private void CollectSections()
@@ -144,10 +153,6 @@ namespace Kamek
             ImportSections(ref blobs, ref location, ".bss");
             _bssEnd = location;
 
-            _kamekStart = location;
-            ImportSections(ref blobs, ref location, ".kamek");
-            _kamekEnd = location;
-
             // Create one big blob from this
             _memory = new byte[location - _baseAddress];
             int position = 0;
@@ -156,26 +161,8 @@ namespace Kamek
                 Array.Copy(blob, 0, _memory, position, blob.Length);
                 position += blob.Length;
             }
-        }
-        #endregion
 
-
-        #region Result Binary Manipulation
-        private ushort ReadUInt16(Word addr)
-        {
-            return Util.ExtractUInt16(_memory, addr - _baseAddress);
-        }
-        private uint ReadUInt32(Word addr)
-        {
-            return Util.ExtractUInt32(_memory, addr - _baseAddress);
-        }
-        private void WriteUInt16(Word addr, ushort value)
-        {
-            Util.InjectUInt16(_memory, addr - _baseAddress, value);
-        }
-        private void WriteUInt32(Word addr, uint value)
-        {
-            Util.InjectUInt32(_memory, addr - _baseAddress, value);
+            ImportHookSections();
         }
         #endregion
 
@@ -194,6 +181,7 @@ namespace Kamek
         }
         private Dictionary<string, Symbol> _globalSymbols = null;
         private Dictionary<Elf, Dictionary<string, Symbol>> _localSymbols = null;
+        private Dictionary<Tuple<Elf.ElfSection, string>, uint> _hookSymbols = null;
         private Dictionary<Elf.ElfSection, SymbolName[]> _symbolTableContents = null;
         private Dictionary<string, uint> _externalSymbols = null;
         private Dictionary<Word, uint> _symbolSizes = null;
@@ -203,6 +191,7 @@ namespace Kamek
         {
             _globalSymbols = new Dictionary<string, Symbol>();
             _localSymbols = new Dictionary<Elf, Dictionary<string, Symbol>>();
+            _hookSymbols = new Dictionary<Tuple<Elf.ElfSection, string>, uint>();
             _symbolTableContents = new Dictionary<Elf.ElfSection, SymbolName[]>();
             _symbolSizes = new Dictionary<Word, uint>();
 
@@ -292,9 +281,15 @@ namespace Kamek
                 {
                     // Part of a section
                     var section = elf.Sections[st_shndx];
-                    if (!_sectionBases.ContainsKey(section))
+                    if (_sectionBases.ContainsKey(section))
+                        addr = _sectionBases[section] + st_value;
+                    else if (_hookSections.Contains(section))
+                    {
+                        _hookSymbols[new Tuple<Elf.ElfSection, string>(section, name)] = st_value;
+                        continue;
+                    }
+                    else
                         continue; // skips past symbols we don't care about, like DWARF junk
-                    addr = _sectionBases[section] + st_value;
                 }
                 else
                     throw new NotImplementedException("unknown section index found in symbol table");
@@ -428,19 +423,24 @@ namespace Kamek
 
                 if (symIndex == 0)
                     throw new InvalidDataException("linking to undefined symbol");
-                if (!_sectionBases.ContainsKey(section))
+
+                Word source;
+                if (_sectionBases.ContainsKey(section))
+                    source = _sectionBases[section] + r_offset;
+                else if (_hookSections.Contains(section))
+                    source = new Word(WordType.Value, r_offset);
+                else
                     continue; // we don't care about this
 
                 SymbolName symbol = _symbolTableContents[symtab][symIndex];
                 string symName = symbol.name;
                 //Console.WriteLine("{0,-30} {1}", symName, reloc);
 
-                Word source = _sectionBases[section] + r_offset;
                 Word dest = (String.IsNullOrEmpty(symName) ? _sectionBases[elf.Sections[symbol.shndx]] : ResolveSymbol(elf, symName).address) + r_addend;
 
                 //Console.WriteLine("Linking from 0x{0:X8} to 0x{1:X8}", source.Value, dest.Value);
 
-                if (!KamekUseReloc(reloc, source, dest))
+                if (!KamekUseReloc(section, reloc, source.Value, dest))
                     _fixups.Add(new Fixup { type = reloc, source = source, dest = dest });
             }
         }
@@ -448,16 +448,16 @@ namespace Kamek
 
 
         #region Kamek Hooks
-        private Dictionary<Word, Word> _kamekRelocations = new Dictionary<Word, Word>();
+        private Dictionary<Tuple<Elf.ElfSection, uint>, Word> _hookRelocations = new Dictionary<Tuple<Elf.ElfSection, uint>, Word>();
 
-        private bool KamekUseReloc(Elf.Reloc type, Word source, Word dest)
+        private bool KamekUseReloc(Elf.ElfSection section, Elf.Reloc type, uint source, Word dest)
         {
-            if (source < _kamekStart || source >= _kamekEnd)
+            if (!_hookSections.Contains(section))
                 return false;
             if (type != Elf.Reloc.R_PPC_ADDR32)
                 throw new InvalidOperationException($"Unsupported relocation type {type} in the Kamek hook data section");
 
-            _kamekRelocations[source] = dest;
+            _hookRelocations[new Tuple<Elf.ElfSection, uint>(section, source)] = dest;
             return true;
         }
 
@@ -473,29 +473,30 @@ namespace Kamek
 
         private void ProcessHooks()
         {
-            foreach (var elf in _modules)
+            foreach (var pair in _hookSymbols)
             {
-                foreach (var pair in _localSymbols[elf])
+                Elf.ElfSection section = pair.Key.Item1;
+                string name = pair.Key.Item2;
+
+                if (name.StartsWith("_kHook"))
                 {
-                    if (pair.Key.StartsWith("_kHook"))
+                    uint cmdOffs = pair.Value;
+
+                    var argCount = Util.ExtractUInt32(section.data, cmdOffs);
+                    var type = Util.ExtractUInt32(section.data, cmdOffs + 4);
+                    var args = new Word[argCount];
+
+                    for (uint i = 0; i < argCount; i++)
                     {
-                        var cmdAddr = pair.Value.address;
-
-                        var argCount = ReadUInt32(cmdAddr);
-                        var type = ReadUInt32(cmdAddr + 4);
-                        var args = new Word[argCount];
-
-                        for (int i = 0; i < argCount; i++)
-                        {
-                            var argAddr = cmdAddr + (8 + (i * 4));
-                            if (_kamekRelocations.ContainsKey(argAddr))
-                                args[i] = _kamekRelocations[argAddr];
-                            else
-                                args[i] = new Word(WordType.Value, ReadUInt32(argAddr));
-                        }
-
-                        _hooks.Add(new HookData { type = type, args = args });
+                        var argOffs = cmdOffs + (8 + (i * 4));
+                        var tuple = new Tuple<Elf.ElfSection, uint>(section, argOffs);
+                        if (_hookRelocations.ContainsKey(tuple))
+                            args[i] = _hookRelocations[tuple];
+                        else
+                            args[i] = new Word(WordType.Value, Util.ExtractUInt32(section.data, argOffs));
                     }
+
+                    _hooks.Add(new HookData { type = type, args = args });
                 }
             }
         }

--- a/Source/Linker.cs
+++ b/Source/Linker.cs
@@ -73,7 +73,107 @@ namespace Kamek
         public long BssSize { get { return _bssEnd - _bssStart; } }
 
 
-        #region Collecting Sections
+        #region Collecting Injection Sections
+
+        [Flags]
+        public enum InjectionFlags : uint
+        {
+            KM_INJECT_STRIP_BLR_PAST = 1,
+            KM_INJECT_ADD_PADDING = 2
+        }
+
+        public struct InjectedSection
+        {
+            public uint Address;
+            public byte[] Data;
+        }
+
+        private List<InjectedSection> _injectedSections = new List<InjectedSection>();
+        public IReadOnlyList<InjectedSection> InjectedSections { get { return _injectedSections; } }
+
+        private void ImportInjectedSections()
+        {
+            foreach (var elf in _modules)
+            {
+                foreach (var injectionSection in (from s in elf.Sections
+                                                  where s.name.StartsWith(".km_inject_") && !s.name.EndsWith("_meta")
+                                                  select s))
+                {
+                    Elf.ElfSection metaSection = (from s in elf.Sections
+                                                  where s.name == $"{injectionSection.name}_meta"
+                                                  select s).Single();
+
+                    var numValues = Util.ExtractUInt32(metaSection.data, 0);
+                    if (numValues < 4)
+                        continue;
+
+                    var startAddr = Util.ExtractUInt32(metaSection.data, 4);
+                    var endAddr = Util.ExtractUInt32(metaSection.data, 8);
+                    var flags = (InjectionFlags)Util.ExtractUInt32(metaSection.data, 12);
+                    var pad = Util.ExtractUInt32(metaSection.data, 16);
+
+                    ProcessSectionInjection(elf, injectionSection, startAddr, endAddr, flags, pad);
+                }
+            }
+        }
+
+        private void ProcessSectionInjection(Elf elf, Elf.ElfSection sec, uint start, uint end, InjectionFlags flags, uint pad)
+        {
+            uint startPreMap = start;
+            uint sizePreMap = end - start;
+
+            start = Mapper.Remap(start);
+            end = Mapper.Remap(end);
+
+            uint sizePostMap = end - start;
+            if (sizePreMap != sizePostMap)
+                throw new InvalidDataException($"Injected code range at 0x{startPreMap:x} changes size when remapped (0x{sizePreMap:x} -> 0x{sizePostMap:x})");
+
+            EnforceSectionInjectionSize(sec, start, end - start + 4, flags, pad);
+
+            _injectedSections.Add(new InjectedSection { Address=start, Data=sec.data });
+            _sectionBases[sec] = new Word(WordType.AbsoluteAddr, start);
+        }
+
+        private void EnforceSectionInjectionSize(Elf.ElfSection sec, uint start, uint requestedSize, InjectionFlags flags, uint pad)
+        {
+            if (sec.sh_size < requestedSize)
+            {
+                // Section data is too short
+
+                if ((flags & InjectionFlags.KM_INJECT_ADD_PADDING) != 0)
+                {
+                    // Pad it with the user-provided pad value
+                    Array.Resize(ref sec.data, (int)requestedSize);
+                    for (uint offs = sec.sh_size; offs < requestedSize; offs += 4)
+                        Util.InjectUInt32(sec.data, offs, pad);
+                    sec.sh_size = requestedSize;
+                }
+            }
+            else if (sec.sh_size > requestedSize)
+            {
+                // Section data is too long
+
+                if ((flags & InjectionFlags.KM_INJECT_STRIP_BLR_PAST) != 0
+                        && sec.sh_size == requestedSize + 4
+                        && Util.ExtractUInt32(sec.data, requestedSize) == 0x4e800020)
+                {
+                    // Section data is too long, but by exactly one "blr" instruction. Instead of
+                    // erroring, make an exception and just trim the blr instead. (This way, users
+                    // don't need to put a "nofralloc" in every single kmWriteDefAsm call.)
+                    Array.Resize(ref sec.data, (int)requestedSize);
+                    sec.sh_size = requestedSize;
+                }
+                else
+                {
+                    throw new InvalidDataException($"Injected code at 0x{start:x} doesn't fit (0x{sec.sh_size:x} > 0x{requestedSize:x})");
+                }
+            }
+        }
+        #endregion
+
+
+        #region Collecting Other Sections
         private Dictionary<Elf.ElfSection, Word> _sectionBases = new Dictionary<Elf.ElfSection, Word>();
         private List<Elf.ElfSection> _hookSections = new List<Elf.ElfSection>();
 
@@ -163,6 +263,7 @@ namespace Kamek
             }
 
             ImportHookSections();
+            ImportInjectedSections();
         }
         #endregion
 

--- a/k_stdlib/kamek.h
+++ b/k_stdlib/kamek.h
@@ -21,6 +21,17 @@
 #define kctInjectCall 4
 #define kctPatchExit 5
 
+// KM_INJECT_STRIP_BLR_PAST (kmWriteDefAsm flag)
+//   If the specified address range has size N, and the compiled code has size
+//   exactly N+4, and the last four bytes are a blr instruction, delete the
+//   instruction instead of raising a link-time error.
+#define KM_INJECT_STRIP_BLR_PAST 0x1
+// KM_INJECT_ADD_PADDING (kmWriteDefAsm flag)
+//   If the specified address range has size N, and the compiled code has size
+//   < N, pad the remaining space with the provided pad value.
+//   (If this flag isn't set, the remaining space is left untouched.)
+#define KM_INJECT_ADD_PADDING 0x2
+
 
 #define kmIdentifier(key, counter) \
 	_k##key##counter
@@ -68,7 +79,6 @@ struct _kmHook_4ui_2f_t { unsigned int a; unsigned int b; unsigned int c; unsign
 #define kmWrite16(addr, value) kmHook3(kctWrite, 3, (addr), (value))
 #define kmWrite8(addr, value) kmHook3(kctWrite, 4, (addr), (value))
 #define kmWriteFloat(addr, value) kmHook_2ui_1f(kctWrite, 2, (addr), (value))
-#define kmWriteNop(addr) kmWrite32((addr), 0x60000000)
 
 // kmPatchExitPoint
 //   Force the end of a Kamek function to always jump to a specific address
@@ -107,5 +117,66 @@ struct _kmHook_4ui_2f_t { unsigned int a; unsigned int b; unsigned int c; unsign
 	kmCallDefInt(__COUNTER__, addr, returnType, __VA_ARGS__)
 #define kmCallDefAsm(addr) \
 	kmCallDefInt(__COUNTER__, addr, asm void, )
+
+#define _kmWriteDefHelper0(pragmaString) _Pragma(#pragmaString)
+#define _kmWriteDefHelper1(secName) \
+	_kmWriteDefHelper0(section data_type sdata_type #secName #secName)
+#define _kmWriteDefHelper2(secName) \
+	_kmWriteDefHelper0(section code_type #secName)
+#define _kmWriteDefHelper3(secName) \
+	__declspec (section #secName)
+
+// kmWriteDefAsm(startAddr[, endAddr[, flags[, pad]]])
+//   Inject assembly code directly into the target executable, overwriting
+//   whatever's there. startAddr and endAddr are the addresses of the first and
+//   last instructions to replace.
+//   - If endAddr is omitted, it defaults to startAddr.
+//   - flags specifies options. Default is `KM_INJECT_STRIP_BLR_PAST | KM_INJECT_ADD_PADDING`.
+//   - pad is the value to fill extra space with if KM_INJECT_ADD_PADDING is set.
+//     Default is nop (0x60000000).
+#define _kmWriteDefAsm3(counter, startAddr, endAddr, flags, pad) \
+	_Pragma("push") \
+	_kmWriteDefHelper1(.km_inject_##counter##_meta) \
+	_kmWriteDefHelper2(.km_inject_##counter) \
+	_kmWriteDefHelper3(.km_inject_##counter##_meta) static const unsigned int kmIdentifier(InjectionMeta, counter) [5] = { 4, (startAddr), (endAddr), (flags), (pad) }; \
+	_kmWriteDefHelper3(.km_inject_##counter) static void kmIdentifier(UserFunc, counter) (); \
+	_Pragma("pop") \
+	static asm void kmIdentifier(UserFunc, counter) ()
+#define _get1stArg(_1, ...) _1
+#define _get2ndArg(_1, _2, ...) _2
+#define _get3rdArg(_1, _2, _3, ...) _3
+#define _get4thArg(_1, _2, _3, _4, ...) _4
+#define _kmWriteDefAsm2(counter, ...) \
+	_kmWriteDefAsm3( \
+		counter, \
+		_get1stArg(__VA_ARGS__, 0), \
+		_get2ndArg(__VA_ARGS__, _get1stArg(__VA_ARGS__, 0), 0), \
+		_get3rdArg(__VA_ARGS__, KM_INJECT_STRIP_BLR_PAST|KM_INJECT_ADD_PADDING, KM_INJECT_STRIP_BLR_PAST|KM_INJECT_ADD_PADDING, 0), \
+		_get4thArg(__VA_ARGS__, 0x60000000, 0x60000000, 0x60000000, 0) \
+	)
+#define kmWriteDefAsm(...) \
+	_kmWriteDefAsm2(__COUNTER__, __VA_ARGS__)
+
+// kmWriteDefCpp
+//   Inject a function defined directly underneath into the target executable,
+//   overwriting whatever function is already there. startAddr and endAddr are
+//   the addresses of the first instruction to replace and the last instruction
+//   that *can* be replaced, respectively.
+#define _kmWriteDefCpp2(counter, startAddr, endAddr, returnType, ...) \
+	_Pragma("push") \
+	_kmWriteDefHelper1(.km_inject_##counter##_meta) \
+	_kmWriteDefHelper2(.km_inject_##counter) \
+	_kmWriteDefHelper3(.km_inject_##counter##_meta) static const unsigned int kmIdentifier(InjectionMeta, counter) [5] = { 4, (startAddr), (endAddr), 0, 0 }; \
+	_kmWriteDefHelper3(.km_inject_##counter) static returnType kmIdentifier(UserFunc, counter) (__VA_ARGS__); \
+	_Pragma("pop") \
+	static returnType kmIdentifier(UserFunc, counter) (__VA_ARGS__)
+#define kmWriteDefCpp(startAddr, endAddr, returnType, ...) \
+	_kmWriteDefCpp2(__COUNTER__, startAddr, endAddr, returnType, __VA_ARGS__)
+
+// kmWriteNop, kmWriteNops
+//   Write one or more nop instructions to an address or address range
+#define kmWriteNop(addr) kmWrite32((addr), 0x60000000)
+#define kmWriteNops(startAddr, endAddr) \
+	kmWriteDefAsm((startAddr), (endAddr)) { nofralloc; nop }
 
 #endif

--- a/k_stdlib/kamek_asm.S
+++ b/k_stdlib/kamek_asm.S
@@ -4,6 +4,10 @@ kctInjectBranch .equ 3
 kctInjectCall .equ 4
 kctPatchExit .equ 5
 
+KM_INJECT_STRIP_BLR_PAST .equ 0x1
+KM_INJECT_ADD_PADDING .equ 0x2
+
+
 // general hook definition macros
 kmHook0: .macro type
 	.section .kamek
@@ -103,9 +107,6 @@ kmWrite8: .macro addr, value
 kmWriteFloat: .macro addr, value
 	kmHook_2ui_1f kctWrite, 2, addr, value
 	.endm
-kmWriteNop: .macro addr
-	kmWrite32 addr, 0x60000000
-	.endm
 
 // kmBranch, kmCall
 //   Set up a branch from a specific instruction to a specific address
@@ -130,6 +131,56 @@ kmBranchDef: .macro addr
 kmCallDef: .macro addr
 	kmCall addr, __kUserFuncCall\@
 	__kUserFuncCall\@:
+	.endm
+
+// kmWriteDefStart startAddr[, endAddr[, flags[, pad]]]
+// kmWriteDefEnd
+//   Inject assembly code directly into the target executable, overwriting
+//   whatever's there. startAddr and endAddr are the addresses of the first and
+//   last instructions to replace.
+//   - If endAddr is omitted, it defaults to startAddr.
+//   - flags specifies options. Default is `KM_INJECT_STRIP_BLR_PAST | KM_INJECT_ADD_PADDING`.
+//   - pad is the value to fill extra space with if KM_INJECT_ADD_PADDING is set.
+//     Default is nop (0x60000000).
+kmWriteDefStart: .macro startAddr, endAddr, flags, pad
+	.section .km_inject_\@_meta
+	_kInjectionMeta\@: .long 4, startAddr
+	.if narg >= 2
+		.long endAddr
+	.else
+		.long startAddr
+	.endif
+	.if narg >= 3
+		.long flags
+	.else
+		.long KM_INJECT_STRIP_BLR_PAST | KM_INJECT_ADD_PADDING
+	.endif
+	.if narg >= 4
+		.long pad
+	.else
+		.long 0x60000000
+	.endif
+	.previous
+	.section .discard
+	li r0, (_kInjectionMeta\@)@l    // reference to prevent CodeWarrior from deleting the symbol
+	li r0, (__kUserFuncInject\@)@l  // ditto
+	.previous
+	.section .km_inject_\@
+	__kUserFuncInject\@:
+	.endm
+kmWriteDefEnd: .macro
+	.previous
+	.endm
+
+// kmWriteNop, kmWriteNops
+//   Write one or more nop instructions to an address or address range
+kmWriteNop: .macro addr
+	kmWrite32 addr, 0x60000000
+	.endm
+kmWriteNops: .macro startAddr, endAddr
+	kmWriteDefStart startAddr, endAddr
+	nop
+	kmWriteDefEnd
 	.endm
 
 // kamek_b, kamek_bl

--- a/kamekfile.bt
+++ b/kamekfile.bt
@@ -37,6 +37,8 @@ if (first8 == 0x4b616d656b000001) {  // "Kamek", version 1
     version = 1;
 } else if (first8 == 0x4b616d656b000002) {  // "Kamek", version 2
     version = 2;
+} else if (first8 == 0x4b616d656b000003) {  // "Kamek", version 3
+    version = 3;
 } else {
     Warning("Not a Kamekfile.");
     return;
@@ -57,6 +59,7 @@ enum <uint8> CommandType {
     kCondWrite32 = 36,
     kCondWrite16 = 37,
     kCondWrite8 = 38,
+    kWriteRange = 39,  // added in version >= 3
     kBranch = 64,
     kBranchLink = 65,
 };
@@ -94,11 +97,15 @@ typedef struct {
     }
 } DestAddress <read=readDestAddress>;
 
+string formatDestAddress(int isAbsolute, uint32 addr) {
+    return Str(isAbsolute ? "0x%x" : "<code+0x%x>", addr);
+}
+
 string readDestAddress(DestAddress &value) {
     if (value.isAbsolute) {
-        return Str("0x%x", value.absAddr);
+        return formatDestAddress(true, value.absAddr);
     } else {
-        return Str("<code+0x%x>", readUint24(value.relAddr));
+        return formatDestAddress(false, readUint24(value.relAddr));
     }
 }
 
@@ -204,6 +211,16 @@ typedef struct {
         uint8 original <name="Original", read=formatHex>;
         valueStr = Str("kmCondWrite8(%s, %s, %s)",
             readDestAddress(dest), formatHex(original), formatHex(value));
+        break;
+    case kWriteRange:
+        uint32 size <name="Size", read=formatHex>;
+        local uint32 startAddr = dest.isAbsolute ? dest.absAddr : dest.relAddr;
+        local uint32 endAddr = startAddr + size;
+        FSkip(startAddr & 3);
+        byte data[size] <name="Data", open=suppress>;
+        FSkip((4 - endAddr) & 3);
+        valueStr = Str("kmWriteRange(%s, %s) {...}",
+            readDestAddress(dest), formatDestAddress(dest.isAbsolute, endAddr - 1));
         break;
     case kBranch:
         SrcAddress src <name="Src. Address", read=readSrcAddress(this, kRel24)>;

--- a/loader/kamekLoader.cpp
+++ b/loader/kamekLoader.cpp
@@ -1,6 +1,6 @@
 #include "kamekLoader.h"
 
-#define KM_FILE_VERSION 2
+#define KM_FILE_VERSION 3
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
@@ -37,6 +37,7 @@ struct DVDHandle
 #define kCondWrite32 36
 #define kCondWrite16 37
 #define kCondWrite8 38
+#define kWriteRange 39
 #define kBranch 64
 #define kBranchLink 65
 
@@ -57,9 +58,9 @@ static inline u32 resolveAddress(u32 text, u32 address) {
 
 
 #define kCommandHandler(name) \
-    static inline const u8 *kHandle##name(const u8 *input, u32 text, u32 address)
+    static inline const u8 *kHandle##name(const u8 *input, u32 text, u32 address, const loaderFunctions *funcs)
 #define kDispatchCommand(name) \
-    case k##name: input = kHandle##name(input, text, address); break
+    case k##name: input = kHandle##name(input, text, address, funcs); break
 
 kCommandHandler(Addr32) {
     u32 target = resolveAddress(text, *(const u32 *)input);
@@ -133,13 +134,22 @@ kCommandHandler(CondWrite8) {
         *(u8 *)address = value & 0xFF;
     return input + 8;
 }
+kCommandHandler(WriteRange) {
+    u32 size = *(const u32 *)input;
+    // skip 1, 2, or 3 bytes to align to 4
+    u32 startOfBuffer = (u32)input + 4 + (address & 3);
+    funcs->memcpy((void *)address, (const void *)(startOfBuffer), (size_t)size);
+    u32 endOfBuffer = startOfBuffer + size;
+    // skip 1, 2, or 3 bytes to align to 4
+    return (const u8 *)((endOfBuffer + 3) & ~3);
+}
 kCommandHandler(Branch) {
     *(u32 *)address = 0x48000000;
-    return kHandleRel24(input, text, address);
+    return kHandleRel24(input, text, address, funcs);
 }
 kCommandHandler(BranchLink) {
     *(u32 *)address = 0x48000001;
-    return kHandleRel24(input, text, address);
+    return kHandleRel24(input, text, address, funcs);
 }
 
 
@@ -218,6 +228,7 @@ void loadKamekBinary(const loaderFunctions *funcs, const void *binary, u32 binar
             kDispatchCommand(CondWrite32);
             kDispatchCommand(CondWrite16);
             kDispatchCommand(CondWrite8);
+            kDispatchCommand(WriteRange);
             kDispatchCommand(Branch);
             kDispatchCommand(BranchLink);
             default:

--- a/loader/kamekLoader.h
+++ b/loader/kamekLoader.h
@@ -12,6 +12,7 @@ typedef bool (*DVDFastOpen_t) (int entrynum, DVDHandle *handle);
 typedef int (*DVDReadPrio_t) (DVDHandle *handle, void *buffer, int length, int offset, int unk);
 typedef bool (*DVDClose_t) (DVDHandle *handle);
 typedef int (*sprintf_t) (char *str, const char *format, ...);
+typedef void *(*memcpy_t) (void *dest, const void *src, size_t count);
 typedef void *(*KamekAlloc_t) (u32 size, bool isForCode, const loaderFunctions *funcs);
 typedef void (*KamekFree_t) (void *buffer, bool isForCode, const loaderFunctions *funcs);
 
@@ -24,6 +25,7 @@ struct loaderFunctions {
     DVDReadPrio_t DVDReadPrio;
     DVDClose_t DVDClose;
     sprintf_t sprintf;
+    memcpy_t memcpy;
     KamekAlloc_t kamekAlloc;
     KamekFree_t kamekFree;
 };

--- a/loader/nsmbw.cpp
+++ b/loader/nsmbw.cpp
@@ -7,7 +7,6 @@
 
 typedef void *(*EGG_Heap_alloc_t) (u32 size, s32 align, void *heap);
 typedef void (*EGG_Heap_free_t) (void *buffer, void *heap);
-typedef void *(*memcpy_t) (void *dest, const void *src, size_t count);
 typedef void (*flush_cache_t) (void *buffer, size_t size);
 
 struct loaderFunctionsEx {
@@ -48,11 +47,11 @@ const loaderFunctionsEx functions_P = {
     (DVDReadPrio_t) 0x801CAC60,
     (DVDClose_t) 0x801CAB40,
     (sprintf_t) 0x802E1ACC,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802B8E00,
     (EGG_Heap_free_t) 0x802B90B0,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x80377F48,
     (void **) 0x8042A72C,
@@ -67,11 +66,11 @@ const loaderFunctionsEx functions_E = {
     (DVDReadPrio_t) 0x801CAB20,
     (DVDClose_t) 0x801CAA00,
     (sprintf_t) 0x802E17DC,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802B8CC0,
     (EGG_Heap_free_t) 0x802B8F70,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x80377C48,
     (void **) 0x8042A44C,
@@ -87,11 +86,11 @@ const loaderFunctionsEx functions_J = {
     (DVDReadPrio_t) 0x801CA930,
     (DVDClose_t) 0x801CA810,
     (sprintf_t) 0x802E15EC,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802B8AD0,
     (EGG_Heap_free_t) 0x802B8D80,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x803779C8,
     (void **) 0x8042A16C,
@@ -106,11 +105,11 @@ const loaderFunctionsEx functions_K = {
     (DVDReadPrio_t) 0x801CB060,
     (DVDClose_t) 0x801CAF40,
     (sprintf_t) 0x802E1D1C,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802B9200,
     (EGG_Heap_free_t) 0x802B94B0,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x80384948,
     (void **) 0x804370EC,
@@ -125,11 +124,11 @@ const loaderFunctionsEx functions_W = {
     (DVDReadPrio_t) 0x801CB060,
     (DVDClose_t) 0x801CAF40,
     (sprintf_t) 0x802E1D1C,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802B9200,
     (EGG_Heap_free_t) 0x802B94B0,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x80382D48,
     (void **) 0x804354EC,
@@ -145,11 +144,11 @@ const loaderFunctionsEx functions_C = {
     (DVDReadPrio_t) 0x801CCE80,
     (DVDClose_t) 0x801CCD60,
     (sprintf_t) 0x802E4DF8,
+    (memcpy_t) 0x80004364,
     allocAdapter,
     freeAdapter},
     (EGG_Heap_alloc_t) 0x802BB360,
     (EGG_Heap_free_t) 0x802BB610,
-    (memcpy_t) 0x80004364,
     (flush_cache_t) 0x80004330,
     (void **) 0x8037D4C8,
     (void **) 0x8042FCCC,
@@ -250,7 +249,7 @@ void loadIntoNSMBW() {
 
     // modify myBackGround_PhaseMethod to load rels earlier & load the kamek binary
     u32 temp[20];
-    sFuncs->memcpy(&temp, sFuncs->myBackGround_PhaseMethod, 0x50);
+    sFuncs->base.memcpy(&temp, sFuncs->myBackGround_PhaseMethod, 0x50);
 
     // set rel loading functions as the first entries in the table
     sFuncs->myBackGround_PhaseMethod[0] = temp[15];
@@ -261,7 +260,7 @@ void loadIntoNSMBW() {
     sFuncs->myBackGround_PhaseMethod[3] = (u32)&loadBinary;
 
     // set all the other functions
-    sFuncs->memcpy(&sFuncs->myBackGround_PhaseMethod[4], &temp, 0x3C);
+    sFuncs->base.memcpy(&sFuncs->myBackGround_PhaseMethod[4], &temp, 0x3C);
     sFuncs->myBackGround_PhaseMethod[19] = temp[18];
     sFuncs->myBackGround_PhaseMethod[20] = temp[19];
 


### PR DESCRIPTION
**Status of this PR:** Tested and working [in both NSMBW-Updated](https://github.com/NSMBW-Community/NSMBW-Updated/pull/5) and a linkage stress-test I made, which will be added to #52 once this PR is merged. I also have some optimizations in mind, but I plan to save those for follow-up PRs.

----
This PR adds a new family of macros that let you "inject" code directly into a specified address range:

C++ (kamek.h):
- `kmWriteDefAsm(startAddr[, endAddr[, flags[, pad]]]) { ... }`
- `kmWriteDefCpp(startAddr, endAddr, returnType, ...) { ... }`
- `kmWriteNops(startAddr, endAddr);`

Assembly (kamek_asm.S):
- `kmWriteDefStart startAddr[, endAddr[, flags[, pad]]]` + `kmWriteDefEnd`
- `kmWriteNops startAddr, endAddr`

This can make certain types of patches cleaner, as well as help reduce patches' memory footprints.

For example, [this patch from NSMBW-Updated](https://github.com/NSMBW-Community/NSMBW-Updated/blob/282dbe0539561cf0f7ea6567485dd09f85caaffc/code/src/nsmbwup_bowsers_castle_door.cpp#L60):
```cpp
kmWrite32(0x8013f41c, 0x28000002);  // cmplwi r0, 2
```
Can now be written as simply:
```cpp
kmWriteDefAsm(0x8013f41c) { cmplwi r0, 2 }
```

Or as a larger example, [this patch](https://github.com/NSMBW-Community/NSMBW-Updated/blob/e1effca1b9056fa7db933668ed179f91535856f2/code/src/nsmbwup_direct_pipes.cpp#L95-L114):
```cpp
kmWrite32(0x800508fc, 0x540007ff);  // clrlwi. r0, r0, 0x1f
kmWrite32(0x80050900, 0x41820014);  // beq NOT_DIRECT_PIPE_END
kmWrite32(0x80050904, 0xa0e30004);  // lhz r7, 4(r3)
kmWrite32(0x80050908, 0x3807fffe);  // subi r0, r7, 0x2
kmWrite32(0x8005090c, 0xb01f042c);  // sth r0, 0x42c(r31)
kmWrite32(0x80050910, 0x4800000c);  // b AFTER_DIRECT_PIPE_END_CHECK
                                    // NOT_DIRECT_PIPE_END:
kmWrite32(0x80050914, 0x38000001);  // li r0, 1
kmWrite32(0x80050918, 0xb01f042c);  // sth r0, 0x42c(r31)
                                    // AFTER_DIRECT_PIPE_END_CHECK:
kmWrite32(0x8005091c, 0xa0a30002);  // lhz r5, 2(r3)
kmWrite32(0x80050920, 0xa89f042c);  // lha r4, 0x42c(r31)
kmWrite32(0x80050924, 0x80c6003c);  // lwz r6, 0x3c(r6)
kmWrite32(0x80050928, 0x7c052214);  // add r0, r5, r4
kmWrite32(0x8005092c, 0x54002036);  // slwi r0, r0, 4
kmWrite32(0x80050930, 0x7ca60214);  // add r5, r6, r0
```
Can be rewritten as:
```cpp
kmWriteDefAsm(0x800508fc, 0x80050930) {
    clrlwi. r0, r0, 0x1f
    beq NOT_DIRECT_PIPE_END
    lhz r7, 4(r3)
    subi r0, r7, 0x2
    sth r0, 0x42c(r31)
    b AFTER_DIRECT_PIPE_END_CHECK
NOT_DIRECT_PIPE_END:
    li r0, 1
    sth r0, 0x42c(r31)
AFTER_DIRECT_PIPE_END_CHECK:
    lhz r5, 2(r3)
    lha r4, 0x42c(r31)
    lwz r6, 0x3c(r6)
    add r0, r5, r4
    slwi r0, r0, 4
    add r5, r6, r0
}
```

Compared to assembling instructions by hand, as in the above examples, not only is this more convenient, but since it's properly integrated with Kamek, **relocations are supported**. That means your injected code can reference game addresses and other custom-code addresses, and Kamek will ensure everything is linked and translated appropriately, just like with other patch types.

For whole-function replacements that were previously done with `kmBranch` and related macros, using `kmWriteDefCpp`/`kmWriteDefAsm` saves memory because **no additional memory is required at all**.[^1] The downside, of course, is that replacement functions cannot be larger than the originals when patched in this way.

[^1]: After the loading process is completed during game boot, at least. Also, some memory might still be required for things like static local variables and string constants, if the new function uses any.

## Usage Details

### C++ macros

#### `kmWriteDefAsm(startAddr[, endAddr[, flags[, pad]]]) { ... }`
Inject assembly code directly into the target executable, overwriting whatever's there.

- `startAddr` and `endAddr` are the addresses of the first and last instructions to replace. If `endAddr` is omitted, it defaults to `startAddr`.
- `flags` specifies options:
  - `KM_INJECT_STRIP_BLR_PAST`: If the specified address range has size N, and the compiled code has size exactly N+4, and the last four bytes are a `blr` instruction, delete the instruction instead of raising a link-time error.
    <details>
    <summary>Rationale</summary>
    This flag makes it possible to write simple patches like
    <pre lang="cpp">
    kmWriteDefAsm(0x8013f41c) { cmplwi r0, 2 }
    </pre>
    without needing to add an explicit `nofralloc` every time.

    This is toggleable because implicit `blr` stripping may be undesirable in some cases.
    </details>
  - `KM_INJECT_ADD_PADDING`: If the specified address range has size N, and the compiled code has size < N, pad the remaining space with the provided pad value. (If this flag isn't set, the remaining space is left untouched.)
    <details>
    <summary>Rationale</summary>
    This flag makes it convenient to replace large chunks of code with a smaller amount of replacement code, without having to carefully count the number of instructions and add an appropriate amount of explicit nops to reach the right length.

    This is toggleable because if the user intends to (say) replace an entire function, padding is unnecessary and would only serve to bloat the compiled patch file size.
    </details>
  - The default is for both of the above flags to be enabled.
- `pad` is the value to fill extra space with if `KM_INJECT_ADD_PADDING` is set. Default is nop (0x60000000).

In most cases, `startAddr` and `endAddr` will be all you need. `flags` and `pad` are expected to be used only rarely.

#### `kmWriteDefCpp(startAddr, endAddr, returnType, ...) { ... }`
Inject a C++ function defined directly underneath into the target executable, overwriting whatever function is already there.

`startAddr` and `endAddr` are the same as in `kmWriteDefAsm`, and the remaining argument(s) are the same as in `kmBranchDefCpp`/`kmCallDefCpp`.

<details>
<summary>Regarding <code>flags</code> and <code>pad</code></summary>
These values are not configurable for this macro, and are both hardcoded to 0. This is because I can't think of any non-contrived use cases for them, and unlike in <code>kmWriteDefAsm</code>, they would <em>always</em> muddy up the macro signature: they can't be added as optional arguments, because the macro already uses optional arguments to collect <em>function</em> arguments.
<br><br>
If a use case is found in the future, we can add a <code>kmWriteDefCppEx</code> macro that includes the extra arguments, or something. But for now, I don't see the point.
</details>

#### `kmWriteNops(startAddr, endAddr);`

This is syntactic sugar for (conceptually) `kmWriteDefAsm(startAddr, endAddr) { }`.

To write a single nop, use `kmWriteNop(addr)` (already in Kamek, not added by this PR).

### Assembly macros

#### `kmWriteDefStart startAddr[, endAddr[, flags[, pad]]]` + `kmWriteDefEnd`

Equivalent to `kmWriteDefAsm` in C++.

```gas
// One-, two-, three-, and four-argument versions are all supported.
// Separate arguments with commas.
kmWriteDefStart 0x8013f41c
    cmplwi r0, 2
kmWriteDefEnd
```
The use of an "end" macro is unfortunately required for technical reasons.

#### `kmWriteNops startAddr, endAddr`

Equivalent to `kmWriteNops` in C++. `kmWriteNop` exists, too.

### Kamekfile format and loader changes

To support this new feature, the loader is updated to use the new Kamekfile v3 format, which adds a new `kWriteRange` command type. The updated loader also now requires game harnesses (e.g. nsmbw.cpp) to supply a `memcpy` pointer in the `loaderFunctions` table.

It's worth pointing out that #59 also increments the Kamekfile version field, currently to 3. Whichever PR is merged second will have its version number changed to 4 instead.

## Implementation notes

### Use of sections

Injected functions are placed in their own sections called `.km_inject_<unique identifier>`.

Unlike other hook types, which use structs in the `.kamek` section to declare their metadata, each injected function declares its metadata in another bespoke section, `.km_inject_<unique identifier>_meta`. This is done to simplify the implementation. Kamek needs to determine every section's base address extremely early in the linking process, and for injection sections, this is part of the hook metadata. On the other hand, hooks in the `.kamek` section are the *last* thing the Linker class processes: it requires relocations to have already been processed, which requires symbols to have already been processed, which requires all sections to already have their base addresses assigned.

In earlier versions of this PR, I experimented with techniques like using multiple processing "passes" or adding stripped-down versions of the symbol-, relocation-, and hook-processing functions so that injection metadata could be parsed earlier. These all ended up much more complicated and ugly than the final approach. Raw section data (apart from relocations, which we don't need for this) is available right at the start of linking, so using extra sections like this is a simple way to convey the information in a way that can be easily parsed when we need to. And just like the `.kamek` section, these extra metadata sections are discarded during the linking process, so this design choice doesn't affect the final output at all.

## Not planned
Using symbol names as targets instead of explicit addresses. For example:
```cpp
// This does NOT work
kmWriteDefAsm(getLength__16dIggyWanKusari_cCFv) { /* ... */ }
```
<details>
<summary>Rationale</summary>
Not only would supporting this make the implementation more complex, but the only possible use case for it would be to replace a function with a <code>blr</code>...
<pre lang="cpp">
// This (still) does NOT work
kmWriteDefAsm(getLength__16dIggyWanKusari_cCFv) { nofralloc; blr }  // (or just leave empty)
</pre>
...since replacing more than one instruction requires specifying the start <em>and</em> end addresses, which would defeat the purpose of using a symbol address in the first place:
<pre lang="cpp">
// Hopefully clearer now why this feature would be kind of pointless
kmWriteDefAsm(getLength__16dIggyWanKusari_cCFv, 0x800b95fc) {
    fsub f1, f1, f1
}
</pre>
</details>

## Discussion: End-address inclusivity/exclusivity
There's an argument to be made for making `endAddr` *exclusive* rather than inclusive. Essentially, instead of thinking of it as "the last instruction to be overwritten", it would instead refer to "the next instruction to be run". This would parallel very nicely with `kmBranchDefAsm` and its `exitPoint` parameter.

A much older version of this branch, from before this PR was made, implemented it that way. However, after thinking about it for a while, and discussing with others, it was decided that the exclusive-upper-bound semantics would be too unintuitive, even if it would match `kmBranchDefAsm` better. So it was changed.