### PR TITLE
Add kmCondBranch and kmCondCall hooks

### DIFF
--- a/Source/Commands/BranchCommand.cs
+++ b/Source/Commands/BranchCommand.cs
@@ -10,61 +10,64 @@ namespace Kamek.Commands
     class BranchCommand : Command
     {
         public readonly Word Target;
+        public readonly Word? Original;
 
-        public BranchCommand(Word source, Word target, bool isLink)
-            : base(isLink ? Ids.BranchLink : Ids.Branch, source)
+        private static Ids IdFromFlags(bool isLink, bool isConditional)
+        {
+            if (isConditional)
+                return isLink ? Ids.CondBranchLink : Ids.CondBranch;
+            else
+                return isLink ? Ids.BranchLink : Ids.Branch;
+
+            throw new NotImplementedException();
+        }
+
+        public BranchCommand(Word source, Word target, Word? original, bool isLink)
+            : base(IdFromFlags(isLink, original.HasValue), source)
         {
             Target = target;
+            Original = original;
         }
 
         public override void WriteArguments(BinaryWriter bw)
         {
             Target.AssertNotAmbiguous();
             bw.WriteBE(Target.Value);
+
+            if (Original.HasValue)
+            {
+                Original.Value.AssertNotRelative();
+                bw.WriteBE(Original.Value.Value);
+            }
         }
 
         public override IEnumerable<string> PackForRiivolution()
         {
-            Address.Value.AssertAbsolute();
-            Target.AssertAbsolute();
-
-            return new string[] { string.Format("<memory offset=\"0x{0:X8}\" value=\"{1:X8}\" />", Address.Value.Value, GenerateInstruction()) };
+            return GenerateWriteCommand().PackForRiivolution();
         }
 
         public override IEnumerable<string> PackForDolphin()
         {
-            Address.Value.AssertAbsolute();
-            Target.AssertAbsolute();
-
-            return new string[] { string.Format("0x{0:X8}:dword:0x{1:X8}", Address.Value.Value, GenerateInstruction()) };
+            return GenerateWriteCommand().PackForDolphin();
         }
 
         public override IEnumerable<ulong> PackGeckoCodes()
         {
-            Address.Value.AssertAbsolute();
-            Target.AssertAbsolute();
-
-            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | GenerateInstruction();
-            code |= 0x4000000UL << 32;
-
-            return new ulong[1] { code };
+            return GenerateWriteCommand().PackGeckoCodes();
         }
 
         public override IEnumerable<ulong> PackActionReplayCodes()
         {
-            Address.Value.AssertAbsolute();
-            Target.AssertAbsolute();
-
-            ulong code = ((ulong)(Address.Value.Value & 0x1FFFFFF) << 32) | GenerateInstruction();
-            code |= 0x4000000UL << 32;
-
-            return new ulong[1] { code };
+            return GenerateWriteCommand().PackActionReplayCodes();
         }
 
         public override bool Apply(KamekFile file)
         {
             if (file.Contains(Address.Value) && Address.Value.Type == Target.Type)
             {
+                if (Original.HasValue && file.ReadUInt32(Address.Value) != Original.Value.Value)
+                    return true;
+
                 file.WriteUInt32(Address.Value, GenerateInstruction());
                 return true;
             }
@@ -74,19 +77,31 @@ namespace Kamek.Commands
 
         public override void ApplyToCodeFile(CodeFiles.CodeFile file)
         {
-            Address.Value.AssertAbsolute();
-            Target.AssertAbsolute();
-
-            file.WriteUInt32(Address.Value.Value, GenerateInstruction());
+            GenerateWriteCommand().ApplyToCodeFile(file);
         }
 
+
+        private WriteCommand GenerateWriteCommand()
+        {
+            Target.AssertAbsolute();
+            return new WriteCommand(
+                Address.Value,
+                new Word(WordType.Value, GenerateInstruction()),
+                WriteCommand.Type.Value32,
+                Original);
+        }
 
         private uint GenerateInstruction()
         {
             long delta = Target - Address.Value;
-            uint insn = (Id == Ids.BranchLink) ? 0x48000001U : 0x48000000U;
+            uint insn = IsLink() ? 0x48000001U : 0x48000000U;
             insn |= ((uint)delta & 0x3FFFFFC);
             return insn;
+        }
+
+        private bool IsLink()
+        {
+            return Id == Ids.BranchLink || Id == Ids.CondBranchLink;
         }
     }
 }

--- a/Source/Commands/Command.cs
+++ b/Source/Commands/Command.cs
@@ -32,6 +32,8 @@ namespace Kamek.Commands
 
             Branch = 64,
             BranchLink = 65,
+            CondBranch = 66,
+            CondBranchLink = 67,
         }
 
         public readonly Ids Id;

--- a/Source/Hooks/BranchHook.cs
+++ b/Source/Hooks/BranchHook.cs
@@ -9,18 +9,20 @@ namespace Kamek.Hooks
 {
     class BranchHook : Hook
     {
-        public BranchHook(bool isLink, Word[] args, AddressMapper mapper)
+        public BranchHook(bool isLink, bool isConditional, Word[] args, AddressMapper mapper)
         {
-            if (args.Length != 2)
+            if (args.Length != (isConditional ? 3 : 2))
                 throw new InvalidDataException("wrong arg count for BranchCommand");
 
             // expected args:
-            //   source : pointer to game code
-            //   dest   : pointer to game code or to Kamek code
+            //   source   : pointer to game code
+            //   dest     : pointer to game code or to Kamek code
+            //   original : value (an encoded PPC instruction, probably)
             var source = GetAbsoluteArg(args[0], mapper);
             var dest = GetAnyPointerArg(args[1], mapper);
+            Word? original = isConditional ? GetValueArg(args[2]) : null;
 
-            Commands.Add(new Commands.BranchCommand(source, dest, isLink));
+            Commands.Add(new Commands.BranchCommand(source, dest, original, isLink));
         }
     }
 }

--- a/Source/Hooks/Hook.cs
+++ b/Source/Hooks/Hook.cs
@@ -12,7 +12,9 @@ namespace Kamek.Hooks
         kctConditionalWrite = 2,
         kctInjectBranch = 3,
         kctInjectCall = 4,
-        kctPatchExit = 5
+        kctPatchExit = 5,
+        kctConditionalInjectBranch = 6,
+        kctConditionalInjectCall = 7
     }
 
     abstract class Hook
@@ -26,9 +28,13 @@ namespace Kamek.Hooks
                 case (uint)HookType.kctConditionalWrite:
                     return new WriteHook(true, data.args, mapper);
                 case (uint)HookType.kctInjectBranch:
-                    return new BranchHook(false, data.args, mapper);
+                    return new BranchHook(false, false, data.args, mapper);
                 case (uint)HookType.kctInjectCall:
-                    return new BranchHook(true, data.args, mapper);
+                    return new BranchHook(true, false, data.args, mapper);
+                case (uint)HookType.kctConditionalInjectBranch:
+                    return new BranchHook(false, true, data.args, mapper);
+                case (uint)HookType.kctConditionalInjectCall:
+                    return new BranchHook(true, true, data.args, mapper);
                 case (uint)HookType.kctPatchExit:
                     return new PatchExitHook(data.args, mapper);
                 default:

--- a/Source/KamekFile.cs
+++ b/Source/KamekFile.cs
@@ -146,8 +146,8 @@ namespace Kamek
             {
                 using (var bw = new BinaryWriter(ms))
                 {
-                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\2'
-                    bw.WriteBE((uint)0x6B000002);
+                    bw.WriteBE((uint)0x4B616D65); // 'Kamek\0\0\3'
+                    bw.WriteBE((uint)0x6B000003);
                     bw.WriteBE((uint)_bssSize);
                     bw.WriteBE((uint)_codeBlob.Length);
                     bw.WriteBE((uint)_ctorStart);

--- a/k_stdlib/kamek.h
+++ b/k_stdlib/kamek.h
@@ -20,6 +20,8 @@
 #define kctInjectBranch 3
 #define kctInjectCall 4
 #define kctPatchExit 5
+#define kctInjectConditionalBranch 6
+#define kctInjectConditionalCall 7
 
 
 #define kmIdentifier(key, counter) \
@@ -79,6 +81,11 @@ struct _kmHook_4ui_2f_t { unsigned int a; unsigned int b; unsigned int c; unsign
 //   Set up a branch from a specific instruction to a specific address
 #define kmBranch(addr, ptr) kmHook2(kctInjectBranch, (addr), (ptr))
 #define kmCall(addr, ptr) kmHook2(kctInjectCall, (addr), (ptr))
+
+// kmCondBranch, kmCondCall
+//   Set up a branch from a specific instruction to a specific address, conditionally
+#define kmCondBranch(addr, original, ptr) kmHook3(kctInjectConditionalBranch, (addr), (ptr), (original))
+#define kmCondCall(addr, original, ptr) kmHook3(kctInjectConditionalCall, (addr), (ptr), (original))
 
 // kmBranchDefCpp, kmBranchDefAsm
 //   Set up a branch (b) from a specific instruction to a function defined

--- a/k_stdlib/kamek_asm.S
+++ b/k_stdlib/kamek_asm.S
@@ -3,6 +3,8 @@ kctConditionalWrite .equ 2
 kctInjectBranch .equ 3
 kctInjectCall .equ 4
 kctPatchExit .equ 5
+kctInjectConditionalBranch .equ 6
+kctInjectConditionalCall .equ 7
 
 // general hook definition macros
 kmHook0: .macro type
@@ -114,6 +116,15 @@ kmBranch: .macro addr, ptr
 	.endm
 kmCall: .macro addr, ptr
 	kmHook2 kctInjectCall, addr, ptr
+	.endm
+
+// kmCondBranch, kmCondCall
+//   Set up a branch from a specific instruction to a specific address, conditionally
+kmCondBranch: .macro addr, original, ptr
+	kmHook3 kctInjectConditionalBranch, addr, ptr, original
+	.endm
+kmCondCall: .macro addr, original, ptr
+	kmHook3 kctInjectConditionalCall, addr, ptr, original
 	.endm
 
 // kmBranchDef

--- a/kamekfile.bt
+++ b/kamekfile.bt
@@ -37,6 +37,8 @@ if (first8 == 0x4b616d656b000001) {  // "Kamek", version 1
     version = 1;
 } else if (first8 == 0x4b616d656b000002) {  // "Kamek", version 2
     version = 2;
+} else if (first8 == 0x4b616d656b000003) {  // "Kamek", version 3
+    version = 3;
 } else {
     Warning("Not a Kamekfile.");
     return;
@@ -59,6 +61,8 @@ enum <uint8> CommandType {
     kCondWrite8 = 38,
     kBranch = 64,
     kBranchLink = 65,
+    kCondBranch = 66,  // added in version >= 3
+    kCondBranchLink = 67,  // added in version >= 3
 };
 
 
@@ -216,6 +220,20 @@ typedef struct {
         // intentionally using kAddr32 instead of kRel24 below
         valueStr = Str("kmCall(%s, %s)",
             readDestAddress(dest), readSrcAddress(src, kAddr32));
+        break;
+    case kCondBranch:
+        SrcAddress src <name="Src. Address", read=readSrcAddress(this, kRel24)>;
+        uint32 original <name="Original", read=formatHex>;
+        // intentionally using kAddr32 instead of kRel24 below
+        valueStr = Str("kmCondBranch(%s, %s, %s)",
+            readDestAddress(dest), formatHex(original), readSrcAddress(src, kAddr32));
+        break;
+    case kCondBranchLink:
+        SrcAddress src <name="Src. Address", read=readSrcAddress(this, kRel24)>;
+        uint32 original <name="Original", read=formatHex>;
+        // intentionally using kAddr32 instead of kRel24 below
+        valueStr = Str("kmCondCall(%s, %s, %s)",
+            readDestAddress(dest), formatHex(original), readSrcAddress(src, kAddr32));
         break;
     default:
         break;

--- a/loader/kamekLoader.cpp
+++ b/loader/kamekLoader.cpp
@@ -1,6 +1,6 @@
 #include "kamekLoader.h"
 
-#define KM_FILE_VERSION 2
+#define KM_FILE_VERSION 3
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
@@ -39,6 +39,8 @@ struct DVDHandle
 #define kCondWrite8 38
 #define kBranch 64
 #define kBranchLink 65
+#define kCondBranch 66
+#define kCondBranchLink 67
 
 
 void kamekError(const loaderFunctions *funcs, const char *str)
@@ -141,6 +143,18 @@ kCommandHandler(BranchLink) {
     *(u32 *)address = 0x48000001;
     return kHandleRel24(input, text, address);
 }
+kCommandHandler(CondBranch) {
+    u32 original = ((const u32 *)input)[1];
+    if (*(u32 *)address == original)
+        kHandleBranch(input, text, address);
+    return input + 8;
+}
+kCommandHandler(CondBranchLink) {
+    u32 original = ((const u32 *)input)[1];
+    if (*(u32 *)address == original)
+        kHandleBranchLink(input, text, address);
+    return input + 8;
+}
 
 
 inline void cacheInvalidateAddress(u32 address) {
@@ -220,6 +234,8 @@ void loadKamekBinary(const loaderFunctions *funcs, const void *binary, u32 binar
             kDispatchCommand(CondWrite8);
             kDispatchCommand(Branch);
             kDispatchCommand(BranchLink);
+            kDispatchCommand(CondBranch);
+            kDispatchCommand(CondBranchLink);
             default:
                 funcs->OSReport("Unknown command: %d\n", cmd);
         }


### PR DESCRIPTION
**Status:** Fully tested, ready to merge.

----

This PR adds new hook types `kmCondBranch` and `kmCondCall`, which work as you'd expect:

```cpp
kmCondBranch(addr, original, ptr);  // if *addr == original, put `b ptr` at addr
kmCondCall(addr, original, ptr);    // if *addr == original, put `bl ptr` at addr
```

The conditional value is a 32-bit integer, as in `kmCondWrite32`. This is expected to be an encoded PPC instruction.

A concrete use case for this is the revamped Super Mario Galaxy / Super Mario Galaxy 2 Kamek loader I'm currently working on. I'm sure it'll be useful more broadly, too.

## Kamekfile format and loader changes
To support this new feature, the loader is updated to use the new Kamekfile v3 format, which adds new `kCondBranch` and `kCondBranchLink` command types. No changes to game harnesses are required.

It's worth pointing out that #54 also increments the Kamekfile version field, currently to 3. Whichever PR is merged second will have its version number changed to 4 instead.

## "Def" versions
"Def" versions of these conditional calls can be easily added in a follow-up PR, if we want to.

## Naming
This naming (`kmCondBranch`, `kmCondCall`) is consistent with other Kamek hooks. However, it's worth pointing out that "conditional branch" is already an established phrase with a different meaning (e.g. `beq`), which is kind of unfortunate.

## Implementation notes
Rather than copypaste all the conditional-write code from the WriteCommand class to BranchCommand, which gets very hairy for certain output formats, I instead simplified the latter by making it delegate output generation to an equivalent WriteCommand when it can. This change fully passes my test suite (#52), so I believe it works correctly.

## Discussion: Format of "original" value
This PR implements (as an example):
```cpp
kmCondCall(0x800db084, 0x4815cc8d, mySinFIdx);
```
Rather than something like:
```cpp
kmCondCall(0x800db084, { bl SinFIdx__Q24nw4r4mathFf }, mySinFIdx);
```

#54 adds the ability to write inline assembly injected into game-code addresses, and it might be tempting to adapt that technique to this case. However -- setting aside the fact that it'd be much more complicated to implement -- I don't think it's actually a good idea.

### Potential benefits

Here are all of the benefits I can think of for being able to write inline assembly as in #54 (ignoring the "memory savings" benefit mentioned in that PR since it obviously doesn't apply here):

- **Readability:** Assembly is more readable than hex values.
- **Editability:** The instructions can be easily edited as source code, rather than having to re-assemble any changes manually.
- **Relocations for custom code:** The instructions can link to other custom code, no matter where it gets loaded to.
- **Relocations for portability:** Kamek can relocate the code properly, no matter where it's placed depending on the game version.

However, in *this* case, the "inline assembly" isn't actually *custom* code, but an instruction from the original game, which is a frozen, unchanging target. So here's how those arguments apply to this case:

<ul>
<li><b>Readability:</b> Probably applies? I think it's debatable, though.
<li><b>Editability:</b> Doesn't apply, since the instruction will never need to be edited, except to change the target address.
<li><b>Relocations for custom code:</b> Doesn't apply, since original game code never links to custom code.
<li><b>Relocations for portability:</b> This one is tricky. In principle, this should be useful, as it would let you convert something like:

<pre lang="c++">
kmCondCall(0x800db084, 0x4815cc8d, mySinFIdx);  // P (800db084)
kmCondCall(0x800db084, 0x4815cc3d, mySinFIdx);  // E (800daf94)
kmCondCall(0x800db084, 0x4815cacd, mySinFIdx);  // J (800daf14)
// K and W don't have this call at all, hence why we're doing it conditionally
</pre>

To the example from earlier:

<pre lang="c++">
kmCondCall(0x800db084, { bl SinFIdx__Q24nw4r4mathFf }, mySinFIdx);  // P, E, J
// K and W don't have this call at all, hence why we're doing it conditionally
</pre>

In fact, the first version above wouldn't even work, as I don't believe Kamek currently lets you define multiple writes to the same address, even if they're conditional. (Maybe that should be changed, but obviously that's out of scope here.) So the second version would be both shorter <em>and</em> would actually work as intended.

However, I believe the <em>main</em> use case for conditional writes is to make static patches that work with multiple game versions, such as Kamek loader harnesses. And static patches that work across game versions don't use address porting at all, so this benefit wouldn't apply. On the other hand, since it's not currently possible to mark writes in dynamic patches as only applying to specific game versions, conditional writes <em>can</em> still have uses in that mode.

All in all, this seems like an argument in favor of the inline-assembly syntax, although it's hard to say how much the hooks would actually be used this way in practice.
</ul>

### Syntax issues

Assembly instructions can have commas (e.g. `li r3, 0`), which I imagine might confuse the preprocessor as it tries to figure out the number of arguments to the hypothetical inline-assembly versions of the macros:
```cpp
kmCondCall(0x800db084, { li r3, 0 }, mySinFIdx);
```
->
- `0x800db084`
- `{ li r3`
- `0 }`
- `mySinFIdx`

Though I haven't tested it to see if it actually works that way.

### Difficulty of implementation

As previously mentioned, this would be much more complicated to implement, which I don't think should be overlooked. It's not just a matter of "would it be better", but also "would it be worth adding that much more complexity to the linker, which would have to be maintained and supported forever."