### PR TITLE
Update .gitignore to add Kamek build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+Kamek.deps.json
+Kamek.dll
+Kamek.dll.config
+Kamek.exe
+Kamek
+Kamek.runtimeconfig.json
 
 # Roslyn cache directories
 *.ide/


### PR DESCRIPTION
Updates .gitignore to add the Kamek build files (before the .NET 10.0 upgrade these were in the .gitignore, but have been moved since)